### PR TITLE
feat(timeout): new property for the notification component

### DIFF
--- a/src/components/notification/inline-notification.ts
+++ b/src/components/notification/inline-notification.ts
@@ -110,7 +110,7 @@ class BXInlineNotification extends FocusMixin(LitElement) {
     if (this._timeoutID) {
       this._cancelTimeout(this._timeoutID);
     }
-    this._timeoutID = setTimeout(this._handleUserOrTimerInitiatedClose.bind(this, null), timeout);
+    this._timeoutID = (setTimeout(this._handleUserOrTimerInitiatedClose.bind(this, null), timeout) as unknown) as number;
   }
 
   /**

--- a/src/components/notification/inline-notification.ts
+++ b/src/components/notification/inline-notification.ts
@@ -110,7 +110,7 @@ class BXInlineNotification extends FocusMixin(LitElement) {
     if (this._timeoutID) {
       this._cancelTimeout(this._timeoutID);
     }
-    this._timeoutID = setTimeout(this._handleUserOrTimerInitiatedClose.bind(this), timeout);
+    this._timeoutID = setTimeout(this._handleUserOrTimerInitiatedClose.bind(this, null), timeout);
   }
 
   /**

--- a/src/components/notification/inline-notification.ts
+++ b/src/components/notification/inline-notification.ts
@@ -93,14 +93,14 @@ class BXInlineNotification extends FocusMixin(LitElement) {
    * @param event The event.
    */
   protected _handleClickCloseButton({ target }: MouseEvent) {
-    this._handleUserInitiatedClose(target);
+    this._handleInitiatedCloseEvent(target);
   }
 
   /**
-   * Handles user-initiated close request of this modal.
-   * @param triggeredBy The element that triggered this close request.
+   * Handles initiated close request of this modal.
+   * @param triggeredBy The element that triggered this close request if there is one.
    */
-  protected _handleUserInitiatedClose(triggeredBy: EventTarget | null) {
+  protected _handleInitiatedCloseEvent(triggeredBy: EventTarget | null | undefined) {
     if (this.open) {
       const init = {
         bubbles: true,
@@ -196,6 +196,12 @@ class BXInlineNotification extends FocusMixin(LitElement) {
   open = true;
 
   /**
+   * Notification time in ms until gets closed.
+   */
+  @property({ type: Number, reflect: true })
+  timeout: number | null | undefined;
+
+  /**
    * The subtitle.
    */
   @property()
@@ -212,6 +218,17 @@ class BXInlineNotification extends FocusMixin(LitElement) {
       this.setAttribute('role', 'alert');
     }
     super.connectedCallback();
+  }
+
+  updated(changedProperties) {
+    const openChanged = changedProperties.has('open');
+    const timeoutChanged = changedProperties.has('timeout');
+
+    if (openChanged || timeoutChanged) {
+      if (this.open && this.timeout) {
+        setTimeout(this._handleInitiatedCloseEvent.bind(this), this.timeout);
+      }
+    }
   }
 
   render() {

--- a/src/components/notification/inline-notification.ts
+++ b/src/components/notification/inline-notification.ts
@@ -224,7 +224,7 @@ class BXInlineNotification extends FocusMixin(LitElement) {
    * Notification time in ms until gets closed.
    */
   @property({ type: Number, reflect: true })
-  timeout?: number | null;
+  timeout: number | null = null;
 
   /**
    * The subtitle.

--- a/src/components/notification/inline-notification.ts
+++ b/src/components/notification/inline-notification.ts
@@ -125,7 +125,7 @@ class BXInlineNotification extends FocusMixin(LitElement) {
    * Handles user-initiated or through timer close request of this modal.
    * @param triggeredBy The element that triggered this close request, if there is one.
    */
-  protected _handleUserOrTimerInitiatedClose(triggeredBy?: EventTarget | null) {
+  protected _handleUserOrTimerInitiatedClose(triggeredBy: EventTarget | null) {
     if (this.open) {
       const init = {
         bubbles: true,

--- a/src/components/notification/inline-notification.ts
+++ b/src/components/notification/inline-notification.ts
@@ -110,27 +110,7 @@ class BXInlineNotification extends FocusMixin(LitElement) {
     if (this._timeoutID) {
       this._cancelTimeout(this._timeoutID);
     }
-    this._timeoutID = setTimeout(this._handleTimerInitiatedClose.bind(this), timeout);
-  }
-
-  /**
-   * Handles timeout close request of this modal.
-   */
-  protected _handleTimerInitiatedClose(triggeredBy: undefined) {
-    if (this.open) {
-      const init = {
-        bubbles: true,
-        cancelable: true,
-        composed: true,
-        detail: {
-          triggeredBy,
-        },
-      };
-      if (this.dispatchEvent(new CustomEvent((this.constructor as typeof BXInlineNotification).eventBeforeClose, init))) {
-        this.open = false;
-        this.dispatchEvent(new CustomEvent((this.constructor as typeof BXInlineNotification).eventClose, init));
-      }
-    }
+    this._timeoutID = setTimeout(this._handleUserOrTimerInitiatedClose.bind(this), timeout);
   }
 
   /**
@@ -138,14 +118,14 @@ class BXInlineNotification extends FocusMixin(LitElement) {
    * @param event The event.
    */
   protected _handleClickCloseButton({ target }: MouseEvent) {
-    this._handleUserInitiatedClose(target);
+    this._handleUserOrTimerInitiatedClose(target);
   }
 
   /**
-   * Handles user-initiated close request of this modal.
-   * @param triggeredBy The element that triggered this close request.
+   * Handles user-initiated or through timer close request of this modal.
+   * @param triggeredBy The element that triggered this close request, if there is one.
    */
-  protected _handleUserInitiatedClose(triggeredBy: EventTarget | null) {
+  protected _handleUserOrTimerInitiatedClose(triggeredBy?: EventTarget | null) {
     if (this.open) {
       const init = {
         bubbles: true,

--- a/src/components/notification/notification-story-angular.ts
+++ b/src/components/notification/notification-story-angular.ts
@@ -22,6 +22,7 @@ export const inline = ({ parameters }) => ({
       [closeButtonLabel]="closeButtonLabel"
       [iconLabel]="iconLabel"
       [open]="open"
+      [timeout]="timeout"
       (bx-notification-beingclosed)="handleBeforeClose($event)"
       (bx-notification-closed)="handleClose($event)"
     >
@@ -56,6 +57,7 @@ export const toast = ({ parameters }) => ({
       [closeButtonLabel]="closeButtonLabel"
       [iconLabel]="iconLabel"
       [open]="open"
+      [timeout]="timeout"
       (bx-notification-beingclosed)="handleBeforeClose($event)"
       (bx-notification-closed)="handleClose($event)"
     >

--- a/src/components/notification/notification-story-react.tsx
+++ b/src/components/notification/notification-story-react.tsx
@@ -29,6 +29,7 @@ export const inline = ({ parameters }) => {
     closeButtonLabel,
     iconLabel,
     open,
+    timeout,
     disableClose,
     onBeforeClose,
     onClose,
@@ -49,6 +50,7 @@ export const inline = ({ parameters }) => {
       closeButtonLabel={closeButtonLabel}
       iconLabel={iconLabel}
       open={open}
+      timeout={timeout}
       onBeforeClose={handleBeforeClose}
       onClose={onClose}
     />
@@ -67,6 +69,7 @@ export const toast = ({ parameters }) => {
     closeButtonLabel,
     iconLabel,
     open,
+    timeout,
     disableClose,
     onBeforeClose,
     onClose,
@@ -88,6 +91,7 @@ export const toast = ({ parameters }) => {
       closeButtonLabel={closeButtonLabel}
       iconLabel={iconLabel}
       open={open}
+      timeout={timeout}
       onBeforeClose={handleBeforeClose}
       onClose={onClose}
     />

--- a/src/components/notification/notification-story-vue.ts
+++ b/src/components/notification/notification-story-vue.ts
@@ -23,6 +23,7 @@ export const inline = ({ parameters }) => ({
       :close-button-label="closeButtonLabel"
       :icon-label="iconLabel"
       :open="open"
+      :timeout="timeout"
       @bx-notification-beingclosed="handleBeforeClose"
       @bx-notification-closed="handleClose"
     >
@@ -56,6 +57,7 @@ export const toast = ({ parameters }) => ({
       :close-button-label="closeButtonLabel"
       :icon-label="iconLabel"
       :open="open"
+      :timeout="timeout"
       @bx-notification-beingclosed="handleBeforeClose"
       @bx-notification-closed="handleClose"
     >

--- a/src/components/notification/notification-story.ts
+++ b/src/components/notification/notification-story.ts
@@ -34,6 +34,7 @@ export const inline = ({ parameters }) => {
     closeButtonLabel,
     iconLabel,
     open,
+    timeout,
     disableClose,
     onBeforeClose = noop,
     onClose = noop,
@@ -54,6 +55,7 @@ export const inline = ({ parameters }) => {
       close-button-label="${ifNonNull(closeButtonLabel)}"
       icon-label="${ifNonNull(iconLabel)}"
       ?open="${open}"
+      timeout="${ifNonNull(timeout)}"
       @bx-notification-beingclosed="${handleBeforeClose}"
       @bx-notification-closed="${onClose}"
     >
@@ -72,6 +74,7 @@ inline.story = {
         closeButtonLabel: textNullable('a11y label for the close button (close-button-label)', ''),
         iconLabel: textNullable('a11y label for the icon (icon-label)', ''),
         open: boolean('Open (open)', true),
+        timeout: textNullable('Timeout (in ms)', ''),
         disableClose: boolean(
           'Disable user-initiated close action (Call event.preventDefault() in bx-notification-beingclosed event)',
           false
@@ -93,6 +96,7 @@ export const toast = ({ parameters }) => {
     closeButtonLabel,
     iconLabel,
     open,
+    timeout,
     disableClose,
     onBeforeClose = noop,
     onClose = noop,
@@ -114,6 +118,7 @@ export const toast = ({ parameters }) => {
       close-button-label="${ifNonNull(closeButtonLabel)}"
       icon-label="${ifNonNull(iconLabel)}"
       ?open="${open}"
+      timeout="${ifNonNull(timeout)}"
       @bx-notification-beingclosed="${handleBeforeClose}"
       @bx-notification-closed="${onClose}"
     >

--- a/tests/spec/notification_spec.ts
+++ b/tests/spec/notification_spec.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -60,6 +60,30 @@ describe('bx-inline-notification', function() {
       notification!.shadowRoot!.querySelector('button')!.click();
       await Promise.resolve();
       expect(notification!.open).toBe(false);
+    });
+  });
+
+  describe('Timeout', function() {
+    const timeout = 100;
+
+    let notification: BXInlineNotification | null;
+
+    beforeEach(async function() {
+      render(
+        inlineTemplate({
+          timeout,
+        }),
+        document.body
+      );
+      await Promise.resolve();
+      notification = document.body.querySelector('bx-inline-notification');
+    });
+
+    it('Should support closing after the timeout', async function() {
+      expect(notification!.open).toBe(true);
+      setTimeout(() => {
+        expect(notification!.open).toBe(false);
+      }, timeout);
     });
   });
 

--- a/tests/spec/notification_spec.ts
+++ b/tests/spec/notification_spec.ts
@@ -69,7 +69,7 @@ describe('bx-inline-notification', function() {
     let notification;
 
     beforeEach(async function() {
-      const initializeTimerCloseEvent = (BXInlineNotification.prototype as any)._handleTimerInitiatedClose;
+      const initializeTimerCloseEvent = (BXInlineNotification.prototype as any)._handleUserOrTimerInitiatedClose;
       spyOn(BXInlineNotification.prototype as any, '_initializeTimeout').and.callFake(function() {
         // TODO: See if we can get around TS2683
         // @ts-ignore

--- a/tests/spec/notification_spec.ts
+++ b/tests/spec/notification_spec.ts
@@ -69,9 +69,16 @@ describe('bx-inline-notification', function() {
     let notification;
 
     beforeEach(async function() {
+      const initializeTimerCloseEvent = (BXInlineNotification.prototype as any)._handleTimerInitiatedClose;
+      spyOn(BXInlineNotification.prototype as any, '_initializeTimeout').and.callFake(function() {
+        // TODO: See if we can get around TS2683
+        // @ts-ignore
+        initializeTimerCloseEvent.call(this);
+      });
       render(
         inlineTemplate({
           timeout,
+          open: false,
         }),
         document.body
       );
@@ -80,13 +87,7 @@ describe('bx-inline-notification', function() {
     });
 
     it('Should support closing after the timeout', async function() {
-      const initializeCloseEvent = (notification as any)._handleInitiatedCloseEvent;
-      spyOn(notification, '_setTimeout').and.callFake(() =>
-        // TODO: See if we can get around TS2683
-        // @ts-ignore
-        initializeCloseEvent.call(this)
-      );
-      expect(notification!.open).toBe(true);
+      notification.open = true;
       await Promise.resolve();
       expect(notification!.open).toBe(false);
     });

--- a/tests/spec/notification_spec.ts
+++ b/tests/spec/notification_spec.ts
@@ -66,7 +66,7 @@ describe('bx-inline-notification', function() {
   describe('Timeout', function() {
     const timeout = 100;
 
-    let notification: BXInlineNotification | null;
+    let notification;
 
     beforeEach(async function() {
       render(
@@ -80,10 +80,15 @@ describe('bx-inline-notification', function() {
     });
 
     it('Should support closing after the timeout', async function() {
+      const initializeCloseEvent = (notification as any)._handleInitiatedCloseEvent;
+      spyOn(notification, '_setTimeout').and.callFake(() =>
+        // TODO: See if we can get around TS2683
+        // @ts-ignore
+        initializeCloseEvent.call(this)
+      );
       expect(notification!.open).toBe(true);
-      setTimeout(() => {
-        expect(notification!.open).toBe(false);
-      }, timeout);
+      await Promise.resolve();
+      expect(notification!.open).toBe(false);
     });
   });
 


### PR DESCRIPTION
### Related Ticket(s)

Fix #291 

### Description

This changes add the property `timeout` to the components `inline-notification` and `toast-notification`. This new property will close the notification if a time (in ms) is specified after that time pass.

### Changelog

**New**

- New property `timeout` for: `inline-notification`, `toast-notification`.

No breaking changes.