### PR TITLE
fix(side-nav): focus on end-animation

### DIFF
--- a/examples/codesandbox/basic/package.json
+++ b/examples/codesandbox/basic/package.json
@@ -17,6 +17,6 @@
   },
   "devDependencies": {
     "@types/lodash-es": "^4.17.0",
-    "snowpack": "^2.7.0"
+    "snowpack": "2.10.1"
   }
 }

--- a/examples/codesandbox/form/basic/package.json
+++ b/examples/codesandbox/form/basic/package.json
@@ -17,6 +17,6 @@
   },
   "devDependencies": {
     "@types/lodash-es": "^4.17.0",
-    "snowpack": "^2.7.0"
+    "snowpack": "2.10.1"
   }
 }

--- a/examples/codesandbox/form/redux-form/package.json
+++ b/examples/codesandbox/form/redux-form/package.json
@@ -30,6 +30,6 @@
     "@snowpack/plugin-dotenv": "^2.0.0",
     "@types/lodash-es": "^4.17.0",
     "@types/react": "^16.9.0",
-    "snowpack": "^2.7.0"
+    "snowpack": "2.10.1"
   }
 }

--- a/examples/codesandbox/react/package.json
+++ b/examples/codesandbox/react/package.json
@@ -24,6 +24,6 @@
     "@snowpack/plugin-dotenv": "^2.0.0",
     "@types/lodash-es": "^4.17.0",
     "@types/react": "^16.9.0",
-    "snowpack": "^2.7.0"
+    "snowpack": "2.10.1"
   }
 }

--- a/examples/codesandbox/styling/custom-style/package.json
+++ b/examples/codesandbox/styling/custom-style/package.json
@@ -17,6 +17,6 @@
   },
   "devDependencies": {
     "@types/lodash-es": "^4.17.0",
-    "snowpack": "^2.7.0"
+    "snowpack": "2.10.1"
   }
 }

--- a/examples/codesandbox/styling/theme-zoning/package.json
+++ b/examples/codesandbox/styling/theme-zoning/package.json
@@ -18,7 +18,7 @@
   "devDependencies": {
     "@snowpack/plugin-dotenv": "^2.0.0",
     "@types/lodash-es": "^4.17.0",
-    "snowpack": "^2.7.0",
+    "snowpack": "2.10.1",
     "snowpack-plugin-sass": "^1.0.0"
   }
 }


### PR DESCRIPTION
### Related Ticket(s)

Refs carbon-design-system/ibm-dotcom-library#3940.

### Description

This change ensures a side nav item is ready to be focused on before side nav sets focus on the first nav item when it's expanded.

### Changelog

**New**

- A mechanism to wait for `transitionend` event before `<bx-side-nav>` sets focus on the first nav item when it's expaneded.