### PR TITLE
fix(components): disable delegatesFocus in Safari

### DIFF
--- a/src/components/button/button.ts
+++ b/src/components/button/button.ts
@@ -183,7 +183,10 @@ class BXButton extends FocusMixin(LitElement) {
   type!: string;
 
   createRenderRoot() {
-    return this.attachShadow({ mode: 'open', delegatesFocus: true });
+    return this.attachShadow({
+      mode: 'open',
+      delegatesFocus: Number((/Safari\/(\d+)/.exec(navigator.userAgent) ?? ['', 0])[1]) <= 537,
+    });
   }
 
   render() {

--- a/src/components/checkbox/checkbox.ts
+++ b/src/components/checkbox/checkbox.ts
@@ -97,7 +97,10 @@ class BXCheckbox extends FocusMixin(FormMixin(LitElement)) {
   value!: string;
 
   createRenderRoot() {
-    return this.attachShadow({ mode: 'open', delegatesFocus: true });
+    return this.attachShadow({
+      mode: 'open',
+      delegatesFocus: Number((/Safari\/(\d+)/.exec(navigator.userAgent) ?? ['', 0])[1]) <= 537,
+    });
   }
 
   render() {

--- a/src/components/code-snippet/code-snippet.ts
+++ b/src/components/code-snippet/code-snippet.ts
@@ -224,7 +224,10 @@ class BXCodeSnippet extends FocusMixin(LitElement) {
   type = CODE_SNIPPET_TYPE.SINGLE;
 
   createRenderRoot() {
-    return this.attachShadow({ mode: 'open', delegatesFocus: true });
+    return this.attachShadow({
+      mode: 'open',
+      delegatesFocus: Number((/Safari\/(\d+)/.exec(navigator.userAgent) ?? ['', 0])[1]) <= 537,
+    });
   }
 
   render() {

--- a/src/components/content-switcher/content-switcher-item.ts
+++ b/src/components/content-switcher/content-switcher-item.ts
@@ -55,7 +55,10 @@ class BXContentSwitcherItem extends FocusMixin(LitElement) {
   value = '';
 
   createRenderRoot() {
-    return this.attachShadow({ mode: 'open', delegatesFocus: true });
+    return this.attachShadow({
+      mode: 'open',
+      delegatesFocus: Number((/Safari\/(\d+)/.exec(navigator.userAgent) ?? ['', 0])[1]) <= 537,
+    });
   }
 
   shouldUpdate(changedProperties) {

--- a/src/components/copy-button/copy-button.ts
+++ b/src/components/copy-button/copy-button.ts
@@ -118,7 +118,10 @@ class BXCopyButton extends FocusMixin(LitElement) {
   feedbackTimeout = 2000;
 
   createRenderRoot() {
-    return this.attachShadow({ mode: 'open', delegatesFocus: true });
+    return this.attachShadow({
+      mode: 'open',
+      delegatesFocus: Number((/Safari\/(\d+)/.exec(navigator.userAgent) ?? ['', 0])[1]) <= 537,
+    });
   }
 
   render() {

--- a/src/components/data-table/table-header-cell.ts
+++ b/src/components/data-table/table-header-cell.ts
@@ -146,7 +146,10 @@ class BXTableHeaderCell extends FocusMixin(LitElement) {
   sortDirection?: TABLE_SORT_DIRECTION;
 
   createRenderRoot() {
-    return this.attachShadow({ mode: 'open', delegatesFocus: true });
+    return this.attachShadow({
+      mode: 'open',
+      delegatesFocus: Number((/Safari\/(\d+)/.exec(navigator.userAgent) ?? ['', 0])[1]) <= 537,
+    });
   }
 
   connectedCallback() {

--- a/src/components/data-table/table-toolbar-search.ts
+++ b/src/components/data-table/table-toolbar-search.ts
@@ -79,7 +79,10 @@ class BXTableToolbarSearch extends HostListenerMixin(BXSearch) {
   size = INPUT_SIZE.SMALL;
 
   createRenderRoot() {
-    return this.attachShadow({ mode: 'open', delegatesFocus: true });
+    return this.attachShadow({
+      mode: 'open',
+      delegatesFocus: Number((/Safari\/(\d+)/.exec(navigator.userAgent) ?? ['', 0])[1]) <= 537,
+    });
   }
 
   connectedCallback() {

--- a/src/components/date-picker/date-picker-input.ts
+++ b/src/components/date-picker/date-picker-input.ts
@@ -246,7 +246,10 @@ class BXDatePickerInput extends ValidityMixin(FocusMixin(LitElement)) {
   value!: string;
 
   createRenderRoot() {
-    return this.attachShadow({ mode: 'open', delegatesFocus: true });
+    return this.attachShadow({
+      mode: 'open',
+      delegatesFocus: Number((/Safari\/(\d+)/.exec(navigator.userAgent) ?? ['', 0])[1]) <= 537,
+    });
   }
 
   render() {

--- a/src/components/dropdown/dropdown.ts
+++ b/src/components/dropdown/dropdown.ts
@@ -501,7 +501,10 @@ class BXDropdown extends ValidityMixin(HostListenerMixin(FocusMixin(LitElement))
   value = '';
 
   createRenderRoot() {
-    return this.attachShadow({ mode: 'open', delegatesFocus: true });
+    return this.attachShadow({
+      mode: 'open',
+      delegatesFocus: Number((/Safari\/(\d+)/.exec(navigator.userAgent) ?? ['', 0])[1]) <= 537,
+    });
   }
 
   shouldUpdate(changedProperties) {

--- a/src/components/floating-menu/floating-menu.ts
+++ b/src/components/floating-menu/floating-menu.ts
@@ -302,7 +302,10 @@ abstract class BXFloatingMenu extends HostListenerMixin(FocusMixin(LitElement)) 
   }
 
   createRenderRoot() {
-    return this.attachShadow({ mode: 'open', delegatesFocus: true });
+    return this.attachShadow({
+      mode: 'open',
+      delegatesFocus: Number((/Safari\/(\d+)/.exec(navigator.userAgent) ?? ['', 0])[1]) <= 537,
+    });
   }
 
   disconnectedCallback() {

--- a/src/components/input/input.ts
+++ b/src/components/input/input.ts
@@ -187,7 +187,10 @@ export default class BXInput extends ValidityMixin(FormMixin(LitElement)) {
   value = '';
 
   createRenderRoot() {
-    return this.attachShadow({ mode: 'open', delegatesFocus: true });
+    return this.attachShadow({
+      mode: 'open',
+      delegatesFocus: Number((/Safari\/(\d+)/.exec(navigator.userAgent) ?? ['', 0])[1]) <= 537,
+    });
   }
 
   render() {

--- a/src/components/link/link.ts
+++ b/src/components/link/link.ts
@@ -88,7 +88,10 @@ class BXLink extends FocusMixin(LitElement) {
   type!: string;
 
   createRenderRoot() {
-    return this.attachShadow({ mode: 'open', delegatesFocus: true });
+    return this.attachShadow({
+      mode: 'open',
+      delegatesFocus: Number((/Safari\/(\d+)/.exec(navigator.userAgent) ?? ['', 0])[1]) <= 537,
+    });
   }
 
   render() {

--- a/src/components/modal/modal-close-button.ts
+++ b/src/components/modal/modal-close-button.ts
@@ -28,7 +28,10 @@ class BXModalCloseButton extends LitElement {
   assistiveText = 'Close';
 
   createRenderRoot() {
-    return this.attachShadow({ mode: 'open', delegatesFocus: true });
+    return this.attachShadow({
+      mode: 'open',
+      delegatesFocus: Number((/Safari\/(\d+)/.exec(navigator.userAgent) ?? ['', 0])[1]) <= 537,
+    });
   }
 
   render() {

--- a/src/components/number-input/number-input.ts
+++ b/src/components/number-input/number-input.ts
@@ -126,7 +126,9 @@ export default class BXNumberInput extends BXInput {
    * The value of the input.
    */
   @property({ reflect: true })
+  // @ts-ignore
   get value() {
+    // FIXME: Figure out how to deal with TS2611
     // once we have the input we can directly query for the value
     if (this._input) {
       return this._input.value;
@@ -202,7 +204,10 @@ export default class BXNumberInput extends BXInput {
   }
 
   createRenderRoot() {
-    return this.attachShadow({ mode: 'open', delegatesFocus: true });
+    return this.attachShadow({
+      mode: 'open',
+      delegatesFocus: Number((/Safari\/(\d+)/.exec(navigator.userAgent) ?? ['', 0])[1]) <= 537,
+    });
   }
 
   render() {

--- a/src/components/overflow-menu/overflow-menu-item.ts
+++ b/src/components/overflow-menu/overflow-menu-item.ts
@@ -39,7 +39,10 @@ class BXOverflowMenuItem extends FocusMixin(LitElement) {
   href = '';
 
   createRenderRoot() {
-    return this.attachShadow({ mode: 'open', delegatesFocus: true });
+    return this.attachShadow({
+      mode: 'open',
+      delegatesFocus: Number((/Safari\/(\d+)/.exec(navigator.userAgent) ?? ['', 0])[1]) <= 537,
+    });
   }
 
   connectedCallback() {

--- a/src/components/pagination/page-sizes-select.ts
+++ b/src/components/pagination/page-sizes-select.ts
@@ -70,7 +70,10 @@ class BXPageSizesSelect extends FocusMixin(LitElement) {
   value!: number;
 
   createRenderRoot() {
-    return this.attachShadow({ mode: 'open', delegatesFocus: true });
+    return this.attachShadow({
+      mode: 'open',
+      delegatesFocus: Number((/Safari\/(\d+)/.exec(navigator.userAgent) ?? ['', 0])[1]) <= 537,
+    });
   }
 
   render() {

--- a/src/components/pagination/pages-select.ts
+++ b/src/components/pagination/pages-select.ts
@@ -65,7 +65,10 @@ class BXPagesSelect extends FocusMixin(LitElement) {
   value!: number;
 
   createRenderRoot() {
-    return this.attachShadow({ mode: 'open', delegatesFocus: true });
+    return this.attachShadow({
+      mode: 'open',
+      delegatesFocus: Number((/Safari\/(\d+)/.exec(navigator.userAgent) ?? ['', 0])[1]) <= 537,
+    });
   }
 
   render() {

--- a/src/components/pagination/pagination.ts
+++ b/src/components/pagination/pagination.ts
@@ -167,7 +167,10 @@ class BXPagination extends FocusMixin(HostListenerMixin(LitElement)) {
   total!: number;
 
   createRenderRoot() {
-    return this.attachShadow({ mode: 'open', delegatesFocus: true });
+    return this.attachShadow({
+      mode: 'open',
+      delegatesFocus: Number((/Safari\/(\d+)/.exec(navigator.userAgent) ?? ['', 0])[1]) <= 537,
+    });
   }
 
   updated(changedProperties) {

--- a/src/components/progress-indicator/progress-step.ts
+++ b/src/components/progress-indicator/progress-step.ts
@@ -116,7 +116,10 @@ class BXProgressStep extends FocusMixin(LitElement) {
   vertical = false;
 
   createRenderRoot() {
-    return this.attachShadow({ mode: 'open', delegatesFocus: true });
+    return this.attachShadow({
+      mode: 'open',
+      delegatesFocus: Number((/Safari\/(\d+)/.exec(navigator.userAgent) ?? ['', 0])[1]) <= 537,
+    });
   }
 
   connectedCallback() {

--- a/src/components/radio-button/radio-button.ts
+++ b/src/components/radio-button/radio-button.ts
@@ -219,7 +219,10 @@ class BXRadioButton extends HostListenerMixin(FocusMixin(LitElement)) {
   value!: string;
 
   createRenderRoot() {
-    return this.attachShadow({ mode: 'open', delegatesFocus: true });
+    return this.attachShadow({
+      mode: 'open',
+      delegatesFocus: Number((/Safari\/(\d+)/.exec(navigator.userAgent) ?? ['', 0])[1]) <= 537,
+    });
   }
 
   disconnectedCallback() {

--- a/src/components/search/search.ts
+++ b/src/components/search/search.ts
@@ -123,7 +123,10 @@ class BXSearch extends FocusMixin(LitElement) {
   value = '';
 
   createRenderRoot() {
-    return this.attachShadow({ mode: 'open', delegatesFocus: true });
+    return this.attachShadow({
+      mode: 'open',
+      delegatesFocus: Number((/Safari\/(\d+)/.exec(navigator.userAgent) ?? ['', 0])[1]) <= 537,
+    });
   }
 
   render() {

--- a/src/components/skip-to-content/skip-to-content.ts
+++ b/src/components/skip-to-content/skip-to-content.ts
@@ -34,7 +34,10 @@ class BXSkipToContent extends FocusMixin(LitElement) {
   href?: string;
 
   createRenderRoot() {
-    return this.attachShadow({ mode: 'open', delegatesFocus: true });
+    return this.attachShadow({
+      mode: 'open',
+      delegatesFocus: Number((/Safari\/(\d+)/.exec(navigator.userAgent) ?? ['', 0])[1]) <= 537,
+    });
   }
 
   connectedCallback() {

--- a/src/components/slider/slider-input.ts
+++ b/src/components/slider/slider-input.ts
@@ -139,7 +139,10 @@ class BXSliderInput extends FocusMixin(LitElement) {
   value!: number;
 
   createRenderRoot() {
-    return this.attachShadow({ mode: 'open', delegatesFocus: true });
+    return this.attachShadow({
+      mode: 'open',
+      delegatesFocus: Number((/Safari\/(\d+)/.exec(navigator.userAgent) ?? ['', 0])[1]) <= 537,
+    });
   }
 
   render() {

--- a/src/components/slider/slider.ts
+++ b/src/components/slider/slider.ts
@@ -353,7 +353,10 @@ class BXSlider extends HostListenerMixin(FormMixin(FocusMixin(LitElement))) {
   value = 50;
 
   createRenderRoot() {
-    return this.attachShadow({ mode: 'open', delegatesFocus: true });
+    return this.attachShadow({
+      mode: 'open',
+      delegatesFocus: Number((/Safari\/(\d+)/.exec(navigator.userAgent) ?? ['', 0])[1]) <= 537,
+    });
   }
 
   connectedCallback() {

--- a/src/components/structured-list/structured-list.ts
+++ b/src/components/structured-list/structured-list.ts
@@ -31,7 +31,10 @@ class BXStructuredList extends FocusMixin(LitElement) {
   selectionName = '';
 
   createRenderRoot() {
-    return this.attachShadow({ mode: 'open', delegatesFocus: true });
+    return this.attachShadow({
+      mode: 'open',
+      delegatesFocus: Number((/Safari\/(\d+)/.exec(navigator.userAgent) ?? ['', 0])[1]) <= 537,
+    });
   }
 
   connectedCallback() {

--- a/src/components/textarea/textarea.ts
+++ b/src/components/textarea/textarea.ts
@@ -163,7 +163,10 @@ export default class BXTextarea extends ValidityMixin(FormMixin(LitElement)) {
   protected _textarea!: HTMLTextAreaElement;
 
   createRenderRoot() {
-    return this.attachShadow({ mode: 'open', delegatesFocus: true });
+    return this.attachShadow({
+      mode: 'open',
+      delegatesFocus: Number((/Safari\/(\d+)/.exec(navigator.userAgent) ?? ['', 0])[1]) <= 537,
+    });
   }
 
   render() {

--- a/src/components/tile/expandable-tile.ts
+++ b/src/components/tile/expandable-tile.ts
@@ -81,7 +81,10 @@ class BXExpandableTile extends HostListenerMixin(FocusMixin(LitElement)) {
   expanded = false;
 
   createRenderRoot() {
-    return this.attachShadow({ mode: 'open', delegatesFocus: true });
+    return this.attachShadow({
+      mode: 'open',
+      delegatesFocus: Number((/Safari\/(\d+)/.exec(navigator.userAgent) ?? ['', 0])[1]) <= 537,
+    });
   }
 
   render() {

--- a/src/components/tile/selectable-tile.ts
+++ b/src/components/tile/selectable-tile.ts
@@ -70,7 +70,10 @@ class BXSelectableTile extends FocusMixin(LitElement) {
   value!: string;
 
   createRenderRoot() {
-    return this.attachShadow({ mode: 'open', delegatesFocus: true });
+    return this.attachShadow({
+      mode: 'open',
+      delegatesFocus: Number((/Safari\/(\d+)/.exec(navigator.userAgent) ?? ['', 0])[1]) <= 537,
+    });
   }
 
   render() {

--- a/src/components/tooltip/tooltip-definition.ts
+++ b/src/components/tooltip/tooltip-definition.ts
@@ -86,7 +86,10 @@ class BXTooltipDefinition extends FocusMixin(LitElement) {
   direction = TOOLTIP_DIRECTION.BOTTOM;
 
   createRenderRoot() {
-    return this.attachShadow({ mode: 'open', delegatesFocus: true });
+    return this.attachShadow({
+      mode: 'open',
+      delegatesFocus: Number((/Safari\/(\d+)/.exec(navigator.userAgent) ?? ['', 0])[1]) <= 537,
+    });
   }
 
   render() {

--- a/src/components/ui-shell/header-menu-button.ts
+++ b/src/components/ui-shell/header-menu-button.ts
@@ -78,7 +78,10 @@ class BXHeaderMenuButton extends FocusMixin(LitElement) {
   usageMode = SIDE_NAV_USAGE_MODE.REGULAR;
 
   createRenderRoot() {
-    return this.attachShadow({ mode: 'open', delegatesFocus: true });
+    return this.attachShadow({
+      mode: 'open',
+      delegatesFocus: Number((/Safari\/(\d+)/.exec(navigator.userAgent) ?? ['', 0])[1]) <= 537,
+    });
   }
 
   render() {

--- a/src/components/ui-shell/header-menu.ts
+++ b/src/components/ui-shell/header-menu.ts
@@ -88,7 +88,10 @@ class BXHeaderMenu extends HostListenerMixin(FocusMixin(LitElement)) {
   menuLabel!: string;
 
   createRenderRoot() {
-    return this.attachShadow({ mode: 'open', delegatesFocus: true });
+    return this.attachShadow({
+      mode: 'open',
+      delegatesFocus: Number((/Safari\/(\d+)/.exec(navigator.userAgent) ?? ['', 0])[1]) <= 537,
+    });
   }
 
   connectedCallback() {

--- a/src/components/ui-shell/header-name.ts
+++ b/src/components/ui-shell/header-name.ts
@@ -34,7 +34,10 @@ class BXHeaderName extends FocusMixin(LitElement) {
   prefix!: string;
 
   createRenderRoot() {
-    return this.attachShadow({ mode: 'open', delegatesFocus: true });
+    return this.attachShadow({
+      mode: 'open',
+      delegatesFocus: Number((/Safari\/(\d+)/.exec(navigator.userAgent) ?? ['', 0])[1]) <= 537,
+    });
   }
 
   render() {

--- a/src/components/ui-shell/header-nav-item.ts
+++ b/src/components/ui-shell/header-nav-item.ts
@@ -34,7 +34,10 @@ class BXHeaderNavItem extends FocusMixin(LitElement) {
   title!: string;
 
   createRenderRoot() {
-    return this.attachShadow({ mode: 'open', delegatesFocus: true });
+    return this.attachShadow({
+      mode: 'open',
+      delegatesFocus: Number((/Safari\/(\d+)/.exec(navigator.userAgent) ?? ['', 0])[1]) <= 537,
+    });
   }
 
   render() {

--- a/src/components/ui-shell/side-nav-link.ts
+++ b/src/components/ui-shell/side-nav-link.ts
@@ -54,7 +54,10 @@ class BXSideNavLink extends FocusMixin(LitElement) {
   title!: string;
 
   createRenderRoot() {
-    return this.attachShadow({ mode: 'open', delegatesFocus: true });
+    return this.attachShadow({
+      mode: 'open',
+      delegatesFocus: Number((/Safari\/(\d+)/.exec(navigator.userAgent) ?? ['', 0])[1]) <= 537,
+    });
   }
 
   connectedCallback() {

--- a/src/components/ui-shell/side-nav-menu-item.ts
+++ b/src/components/ui-shell/side-nav-menu-item.ts
@@ -41,7 +41,10 @@ class BXSideNavMenuItem extends FocusMixin(LitElement) {
   title!: string;
 
   createRenderRoot() {
-    return this.attachShadow({ mode: 'open', delegatesFocus: true });
+    return this.attachShadow({
+      mode: 'open',
+      delegatesFocus: Number((/Safari\/(\d+)/.exec(navigator.userAgent) ?? ['', 0])[1]) <= 537,
+    });
   }
 
   shouldUpdate(changedProperties) {

--- a/src/components/ui-shell/side-nav-menu.ts
+++ b/src/components/ui-shell/side-nav-menu.ts
@@ -111,7 +111,10 @@ class BXSideNavMenu extends FocusMixin(LitElement) {
   title = '';
 
   createRenderRoot() {
-    return this.attachShadow({ mode: 'open', delegatesFocus: true });
+    return this.attachShadow({
+      mode: 'open',
+      delegatesFocus: Number((/Safari\/(\d+)/.exec(navigator.userAgent) ?? ['', 0])[1]) <= 537,
+    });
   }
 
   connectedCallback() {


### PR DESCRIPTION
### Related Ticket(s)

Fixes #494.

### Description

This change disables `delegatesFocus` feature in shadow DOM in recent Safari, notably `14.x`. Safari `14.x` introduced `delegatesFocus`, but using such feature causes browser crash, as reported at: https://bugs.webkit.org/show_bug.cgi?id=215622.

The WebKit version threshold is chosen as it's the number of Blink fork. It means:

* Safari after Blink fork: `delegatesFocus` is disabled (for now)
* Other brwosers, including Chrome: `delegatesFocus` is enabled, as long as the browser supports it

### Changelog

**Changed**

- Disable `delegatesFocus` feature in shadow DOM in recent Safari.