### PR TITLE
feat(accordion): add disabled state to accordion item

### DIFF
--- a/src/components/accordion/accordion-item.ts
+++ b/src/components/accordion/accordion-item.ts
@@ -124,7 +124,13 @@ class BXAccordionItem extends FocusMixin(LitElement) {
   });
 
   /**
-   * `true` if the check box should be open.
+   * `true` if the accordion item should be disabled.
+   */
+  @property({ type: Boolean, reflect: true })
+  disabled = false;
+
+  /**
+   * `true` if the accordion item should be open.
    */
   @property({ type: Boolean, reflect: true })
   open = false;
@@ -154,6 +160,7 @@ class BXAccordionItem extends FocusMixin(LitElement) {
 
   render() {
     const {
+      disabled,
       titleText,
       open,
       _currentBreakpoint: currentBreakpoint,
@@ -168,6 +175,7 @@ class BXAccordionItem extends FocusMixin(LitElement) {
     });
     return html`
       <button
+        ?disabled="${disabled}"
         type="button"
         part="expando"
         class="${prefix}--accordion__heading"

--- a/src/components/accordion/accordion-story-angular.ts
+++ b/src/components/accordion/accordion-story-angular.ts
@@ -17,7 +17,7 @@ export const Default = args => ({
       (bx-accordion-item-beingtoggled)="handleBeforeToggle($event)"
       (bx-accordion-item-toggled)="handleToggle($event)"
     >
-      <bx-accordion-item [open]="open" [titleText]="titleText">
+      <bx-accordion-item [open]="open" [titleText]="titleText" [disabled]="disabled">
         <p>
           Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna
           aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.

--- a/src/components/accordion/accordion-story-react.tsx
+++ b/src/components/accordion/accordion-story-react.tsx
@@ -19,7 +19,7 @@ import { Default as baseDefault } from './accordion-story';
 export { default } from './accordion-story';
 
 export const Default = args => {
-  const { open, titleText, disableToggle, onBeforeToggle, onToggle } = args?.['bx-accordion'];
+  const { disabled, open, titleText, disableToggle, onBeforeToggle, onToggle } = args?.['bx-accordion'];
   const handleBeforeToggle = (event: CustomEvent) => {
     onBeforeToggle(event);
     if (disableToggle) {
@@ -28,7 +28,12 @@ export const Default = args => {
   };
   return (
     <BXAccordion>
-      <BXAccordionItem open={open} titleText={titleText} onBeforeToggle={handleBeforeToggle} onToggle={onToggle}>
+      <BXAccordionItem
+        open={open}
+        titleText={titleText}
+        onBeforeToggle={handleBeforeToggle}
+        onToggle={onToggle}
+        disabled={disabled}>
         <p>
           Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna
           aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.

--- a/src/components/accordion/accordion-story-vue.ts
+++ b/src/components/accordion/accordion-story-vue.ts
@@ -18,7 +18,7 @@ export const Default = args => ({
       @bx-accordion-item-beingtoggled="handleBeforeToggle"
       @bx-accordion-item-toggled="handleToggle"
     >
-      <bx-accordion-item :open="open" :title-text="titleText">
+      <bx-accordion-item :open="open" :title-text="titleText" :disabled="disabled">
         <p>
           Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna
           aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.

--- a/src/components/accordion/accordion-story.ts
+++ b/src/components/accordion/accordion-story.ts
@@ -17,7 +17,7 @@ import storyDocs from './accordion-story.mdx';
 const noop = () => {};
 
 export const Default = args => {
-  const { open, titleText, disableToggle, onBeforeToggle = noop, onToggle = noop } = args?.['bx-accordion'] ?? {};
+  const { open, titleText, disabled, disableToggle, onBeforeToggle = noop, onToggle = noop } = args?.['bx-accordion'] ?? {};
   const handleBeforeToggle = (event: CustomEvent) => {
     onBeforeToggle(event);
     if (disableToggle) {
@@ -26,7 +26,7 @@ export const Default = args => {
   };
   return html`
     <bx-accordion @bx-accordion-item-beingtoggled="${handleBeforeToggle}" @bx-accordion-item-toggled="${onToggle}">
-      <bx-accordion-item ?open="${open}" title-text=${titleText}>
+      <bx-accordion-item ?disabled="${disabled}" ?open="${open}" title-text=${titleText}>
         <p>
           Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna
           aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
@@ -59,6 +59,7 @@ export default {
       'bx-accordion': () => ({
         open: boolean('Open the section (open)', false),
         titleText: text('The title (title-text)', 'Section title'),
+        disabled: boolean('Disable accordion item (disabled)', false),
         disableToggle: boolean(
           'Disable user-initiated toggle action (Call event.preventDefault() in bx-accordion-beingtoggled event)',
           false

--- a/src/components/accordion/accordion.scss
+++ b/src/components/accordion/accordion.scss
@@ -25,7 +25,7 @@ $css--plex: true !default;
   }
 }
 
-:host(#{$prefix}-accordion-item[open]) {
+:host(#{$prefix}-accordion-item[open]:not([disabled])) {
   @extend .#{$prefix}--accordion__item--active;
 
   .#{$prefix}--accordion__content {


### PR DESCRIPTION
### Related Ticket(s)

#525 

### Description

Adds disabled state to accordion items.

![image](https://user-images.githubusercontent.com/909118/100376709-ffc04280-2fdd-11eb-9d5b-fc960a9646e0.png)


### Changelog

**New**

- `disabled` state added to accordion items

**Changed**

- update CSS for disabled state when `open` is true

