### PR TITLE
feat(button): add tertiary and ghost variants to danger

### DIFF
--- a/src/components/button/button-story.ts
+++ b/src/components/button/button-story.ts
@@ -25,6 +25,8 @@ const kinds = {
   [`Secondary button (${BUTTON_KIND.SECONDARY})`]: BUTTON_KIND.SECONDARY,
   [`Tertiary button (${BUTTON_KIND.TERTIARY})`]: BUTTON_KIND.TERTIARY,
   [`Danger button (${BUTTON_KIND.DANGER})`]: BUTTON_KIND.DANGER,
+  [`Danger tertiary button (${BUTTON_KIND.DANGER_TERTIARY})`]: BUTTON_KIND.DANGER_TERTIARY,
+  [`Danger ghost button (${BUTTON_KIND.DANGER_GHOST})`]: BUTTON_KIND.DANGER_GHOST,
   [`Ghost button (${BUTTON_KIND.GHOST})`]: BUTTON_KIND.GHOST,
 };
 

--- a/src/components/button/button.ts
+++ b/src/components/button/button.ts
@@ -36,9 +36,19 @@ export enum BUTTON_KIND {
   TERTIARY = 'tertiary',
 
   /**
+   * Danger tertiary button.
+   */
+  DANGER_TERTIARY = 'danger-tertiary',
+
+  /**
    * Danger button.
    */
   DANGER = 'danger',
+
+  /**
+   * Danger ghost button,
+   */
+  DANGER_GHOST = 'danger-ghost',
 
   /**
    * Ghost button.


### PR DESCRIPTION
### Related Ticket(s)

#534 

### Description

Adds tertiary and ghost variations to `danger` button.

### Changelog

**New**

- tertiary and ghost variations to `danger`

