### PR TITLE
test(integration-ui): fix for WebKit

### DIFF
--- a/src/components/modal/modal-story.scss
+++ b/src/components/modal/modal-story.scss
@@ -1,0 +1,14 @@
+//
+// Copyright IBM Corp. 2020
+//
+// This source code is licensed under the Apache-2.0 license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+bx-modal[open] {
+  // `@extend` usage in the corresponding rule in `modal.scss` causes the ruleset defined after `:host(bx-modal)`,
+  // which itself is OK, but it causes an adverse effect in Playwright WebKit environment
+  // TODO: Upgrade Playwright soon
+  opacity: 1;
+  visibility: inherit;
+}

--- a/src/components/modal/modal-story.ts
+++ b/src/components/modal/modal-story.ts
@@ -19,6 +19,7 @@ import './modal-heading';
 import './modal-label';
 import './modal-body';
 import './modal-footer';
+import styles from './modal-story.scss';
 import storyDocs from './modal-story.mdx';
 
 const sizes = {
@@ -56,6 +57,14 @@ Default.storyName = 'Default';
 
 export default {
   title: 'Components/Modal',
+  decorators: [
+    story => html`
+      <style type="text/css">
+        ${styles.cssText}
+      </style>
+      ${story()}
+    `,
+  ],
   parameters: {
     ...storyDocs.parameters,
     knobs: {


### PR DESCRIPTION
### Description

WebKit in the version of Playwright we are with seems to have a problem where `:host(bx-modal[open])` is defined before `:host(bx-modal)`.

This fixes the UI integration test failure caused by such problem.

### Changelog

**Changed**

- Workaround a problem in WebKit used in the Playwright version we are using that happens when 
`:host(bx-modal[open])` is defined before `:host(bx-modal)`.