### PR TITLE
docs(examples): update React SSR

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,14 @@ render(<App />, document.getElementById('root'));
 
 Note: Using the React wrapper requires an additional dependency, [`prop-types`](https://www.npmjs.com/package/prop-types).
 
+To run the wrapper React components in SSR environment requires Node `12.16.3` or above that supports ["conditional mapping" feature](https://github.com/jkrems/proposal-pkg-exports#2-conditional-mapping):
+
+[![Edit carbon-web-components with React SSR](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/carbon-design-system/carbon-web-components/tree/master/examples/codesandbox/react-ssr)
+
+Same Node version requirement applies to Next.js:
+
+[![Edit carbon-web-components with React SSR](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/carbon-design-system/carbon-web-components/tree/master/examples/codesandbox/next)
+
 ### Vue
 
 [![Edit carbon-web-components with Vue](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/carbon-design-system/carbon-web-components/tree/master/examples/codesandbox/vue)

--- a/examples/codesandbox/next/package.json
+++ b/examples/codesandbox/next/package.json
@@ -4,16 +4,17 @@
   "private": true,
   "description": "Sample project for getting started with the Web Components from the Carbon Design System with Next.js.",
   "scripts": {
-    "start": "next"
+    "start": "echo 'Running Next in Node 12.16.3+. If you have such Node version in your system just `next` here will work.' && ./node_modules/node/node_modules/.bin/node ./node_modules/.bin/next"
   },
   "license": "Apache-2",
   "dependencies": {
-    "carbon-components": "~10.23.0",
-    "carbon-web-components": "^1.7.0",
+    "carbon-components": "~10.25.0",
+    "carbon-web-components": "^1.10.0",
     "lit-element": "~2.4.0",
     "lit-html": "~1.3.0",
     "lodash-es": "^4.17.0",
     "next": "^10.0.0",
+    "node": "^12.16.3",
     "react": "^17.0.0",
     "react-dom": "^17.0.0"
   }

--- a/examples/codesandbox/react-ssr/package.json
+++ b/examples/codesandbox/react-ssr/package.json
@@ -7,11 +7,11 @@
   "scripts": {
     "build:views": "babel src/views -d views --plugins=@babel/plugin-transform-react-jsx,@babel/plugin-transform-modules-commonjs",
     "prestart": "yarn build:views",
-    "start": "node app.js"
+    "start": "echo 'Running server in Node 12.16.3+. If you have such Node version in your system just `node app.js` here will work.' && ./node_modules/node/node_modules/.bin/node app.js"
   },
   "dependencies": {
-    "carbon-components": "~10.23.0",
-    "carbon-web-components": "^1.7.0",
+    "carbon-components": "~10.25.0",
+    "carbon-web-components": "^1.10.0",
     "express": "^4.17.0",
     "lit-element": "~2.4.0",
     "lit-html": "~1.3.0",
@@ -30,6 +30,7 @@
     "@types/react": "^16.9.0",
     "babel-loader": "^8.2.0",
     "css-loader": "^5.0.0",
+    "node": "^12.16.3",
     "style-loader": "^2.0.0",
     "webpack": "^4.0.0",
     "webpack-dev-middleware": "^4.0.0"


### PR DESCRIPTION
### Related Ticket(s)

Refs carbon-design-system/carbon-for-ibm-dotcom#4251.

### Description

Ensures React SSR and Next CodeSandbox examples run on Node `12.16.3`+ given CodeSandbox runs on older Node version by default.

### Changelog

**Changed**

- Ensures React SSR and Next CodeSandbox examples run on Node `12.16.3`+.