### PR TITLE
feat(accordion): add size variants

### DIFF
--- a/src/components/accordion/accordion-story-angular.ts
+++ b/src/components/accordion/accordion-story-angular.ts
@@ -16,6 +16,7 @@ export const Default = args => ({
     <bx-accordion
       (bx-accordion-item-beingtoggled)="handleBeforeToggle($event)"
       (bx-accordion-item-toggled)="handleToggle($event)"
+      [size]="size"
     >
       <bx-accordion-item [open]="open" [titleText]="titleText" [disabled]="disabled">
         <p>
@@ -29,7 +30,7 @@ export const Default = args => ({
           aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
         </p>
       </bx-accordion-item>
-      <bx-accordion-item [open]="open">
+      <bx-accordion-item [open]="open" [titleText]="titleText">
         <p>
           Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna
           aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.

--- a/src/components/accordion/accordion-story-react.tsx
+++ b/src/components/accordion/accordion-story-react.tsx
@@ -19,7 +19,7 @@ import { Default as baseDefault } from './accordion-story';
 export { default } from './accordion-story';
 
 export const Default = args => {
-  const { disabled, open, titleText, disableToggle, onBeforeToggle, onToggle } = args?.['bx-accordion'];
+  const { disabled, open, titleText, disableToggle, onBeforeToggle, onToggle, size } = args?.['bx-accordion'];
   const handleBeforeToggle = (event: CustomEvent) => {
     onBeforeToggle(event);
     if (disableToggle) {
@@ -33,7 +33,8 @@ export const Default = args => {
         titleText={titleText}
         onBeforeToggle={handleBeforeToggle}
         onToggle={onToggle}
-        disabled={disabled}>
+        disabled={disabled}
+        size={size}>
         <p>
           Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna
           aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.

--- a/src/components/accordion/accordion-story-vue.ts
+++ b/src/components/accordion/accordion-story-vue.ts
@@ -18,19 +18,19 @@ export const Default = args => ({
       @bx-accordion-item-beingtoggled="handleBeforeToggle"
       @bx-accordion-item-toggled="handleToggle"
     >
-      <bx-accordion-item :open="open" :title-text="titleText" :disabled="disabled">
+      <bx-accordion-item :open="open" :title-text="titleText" :disabled="disabled" :size="size">
         <p>
           Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna
           aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
         </p>
       </bx-accordion-item>
-      <bx-accordion-item :open="open" :title-text="titleText">
+      <bx-accordion-item :open="open" :title-text="titleText" :size="size">
         <p>
           Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna
           aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
         </p>
       </bx-accordion-item>
-      <bx-accordion-item :open="open">
+      <bx-accordion-item :open="open" :size="size">
         <p>
           Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna
           aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.

--- a/src/components/accordion/accordion-story.ts
+++ b/src/components/accordion/accordion-story.ts
@@ -9,15 +9,21 @@
 
 import { html } from 'lit-element';
 import { action } from '@storybook/addon-actions';
-import { boolean, text } from '@storybook/addon-knobs';
-import './accordion';
+import { boolean, select, text } from '@storybook/addon-knobs';
+import { ACCORDION_SIZE } from './accordion';
 import './accordion-item';
 import storyDocs from './accordion-story.mdx';
+
+const sizes = {
+  'Regular size': null,
+  [`Small size (${ACCORDION_SIZE.SMALL})`]: ACCORDION_SIZE.SMALL,
+  [`XL size (${ACCORDION_SIZE.EXTRA_LARGE})`]: ACCORDION_SIZE.EXTRA_LARGE,
+};
 
 const noop = () => {};
 
 export const Default = args => {
-  const { open, titleText, disabled, disableToggle, onBeforeToggle = noop, onToggle = noop } = args?.['bx-accordion'] ?? {};
+  const { open, titleText, disabled, disableToggle, onBeforeToggle = noop, onToggle = noop, size } = args?.['bx-accordion'] ?? {};
   const handleBeforeToggle = (event: CustomEvent) => {
     onBeforeToggle(event);
     if (disableToggle) {
@@ -25,7 +31,7 @@ export const Default = args => {
     }
   };
   return html`
-    <bx-accordion @bx-accordion-item-beingtoggled="${handleBeforeToggle}" @bx-accordion-item-toggled="${onToggle}">
+    <bx-accordion @bx-accordion-item-beingtoggled="${handleBeforeToggle}" @bx-accordion-item-toggled="${onToggle}" size="${size}">
       <bx-accordion-item ?disabled="${disabled}" ?open="${open}" title-text=${titleText}>
         <p>
           Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna
@@ -59,6 +65,7 @@ export default {
       'bx-accordion': () => ({
         open: boolean('Open the section (open)', false),
         titleText: text('The title (title-text)', 'Section title'),
+        size: select('Accordion size (size)', sizes, null),
         disabled: boolean('Disable accordion item (disabled)', false),
         disableToggle: boolean(
           'Disable user-initiated toggle action (Call event.preventDefault() in bx-accordion-beingtoggled event)',

--- a/src/components/accordion/accordion.scss
+++ b/src/components/accordion/accordion.scss
@@ -23,6 +23,19 @@ $css--plex: true !default;
     padding-top: calc((#{$container-03} - #{map-get($body-long-01, 'line-height')}rem) / 2);
     min-height: $container-03;
   }
+
+  &[size='sm'] {
+    .#{$prefix}--accordion__heading {
+      min-height: rem(32px);
+      padding: rem(5px) 0;
+    }
+  }
+
+  &[size='xl'] {
+    .#{$prefix}--accordion__heading {
+      min-height: rem(48px);
+    }
+  }
 }
 
 :host(#{$prefix}-accordion-item[open]:not([disabled])) {

--- a/src/components/accordion/accordion.ts
+++ b/src/components/accordion/accordion.ts
@@ -7,9 +7,13 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import { html, property, customElement, LitElement } from 'lit-element';
 import settings from 'carbon-components/es/globals/js/settings';
-import { html, customElement, LitElement } from 'lit-element';
+import { forEach } from '../../globals/internal/collection-helpers';
+import { ACCORDION_SIZE } from './defs';
 import styles from './accordion.scss';
+
+export { ACCORDION_SIZE };
 
 const { prefix } = settings;
 
@@ -19,6 +23,12 @@ const { prefix } = settings;
  */
 @customElement(`${prefix}-accordion`)
 class BXAccordion extends LitElement {
+  /**
+   * Accordion size.
+   */
+  @property({ reflect: true })
+  size = ACCORDION_SIZE.REGULAR;
+
   connectedCallback() {
     if (!this.hasAttribute('role')) {
       this.setAttribute('role', 'list');
@@ -26,10 +36,23 @@ class BXAccordion extends LitElement {
     super.connectedCallback();
   }
 
+  updated(changedProperties) {
+    if (changedProperties.has('size')) {
+      // Propagate `size` attribute to descendants until `:host-context()` gets supported in all major browsers
+      forEach(this.querySelectorAll((this.constructor as typeof BXAccordion).selectorAccordionItems), elem => {
+        elem.setAttribute('size', this.size);
+      });
+    }
+  }
+
   render() {
     return html`
       <slot></slot>
     `;
+  }
+
+  static get selectorAccordionItems() {
+    return `${prefix}-accordion-item`;
   }
 
   static styles = styles;

--- a/src/components/accordion/defs.ts
+++ b/src/components/accordion/defs.ts
@@ -21,3 +21,23 @@ export enum ACCORDION_ITEM_BREAKPOINT {
    */
   MEDIUM = 'md',
 }
+
+/**
+ * Button size.
+ */
+export enum ACCORDION_SIZE {
+  /**
+   * Regular size.
+   */
+  REGULAR = '',
+
+  /**
+   * Small size.
+   */
+  SMALL = 'sm',
+
+  /**
+   * X-Large size.
+   */
+  EXTRA_LARGE = 'xl',
+}


### PR DESCRIPTION
### Related Ticket(s)

#529 

### Description

This adds size variants to `accordion`.

### Changelog

**New**

- `sm` and `xl` sizes

