### PR TITLE
feat(overflow-menu): add size variants

### DIFF
--- a/src/components/overflow-menu/defs.ts
+++ b/src/components/overflow-menu/defs.ts
@@ -8,3 +8,23 @@
  */
 
 export { FORM_ELEMENT_COLOR_SCHEME as OVERFLOW_MENU_COLOR_SCHEME } from '../../globals/shared-enums';
+
+/**
+ * Overflow menu size.
+ */
+export enum OVERFLOW_MENU_SIZE {
+  /**
+   * Regular size.
+   */
+  REGULAR = '',
+
+  /**
+   * Small size.
+   */
+  SMALL = 'sm',
+
+  /**
+   * X-Large size.
+   */
+  EXTRA_LARGE = 'xl',
+}

--- a/src/components/overflow-menu/overflow-menu-story-angular.ts
+++ b/src/components/overflow-menu/overflow-menu-story-angular.ts
@@ -13,7 +13,7 @@ import baseStory, { Default as baseDefault } from './overflow-menu-story';
 
 export const Default = args => ({
   template: `
-    <bx-overflow-menu [open]="open" [colorScheme]="colorScheme" [disabled]="disabled">
+    <bx-overflow-menu [open]="open" [colorScheme]="colorScheme" [disabled]="disabled" [size]="size">
       <bx-overflow-menu-body [direction]="direction">
         <bx-overflow-menu-item>Option 1</bx-overflow-menu-item>
         <bx-overflow-menu-item>Option 2</bx-overflow-menu-item>

--- a/src/components/overflow-menu/overflow-menu-story-react.tsx
+++ b/src/components/overflow-menu/overflow-menu-story-react.tsx
@@ -21,9 +21,9 @@ import { Default as baseDefault } from './overflow-menu-story';
 export { default } from './overflow-menu-story';
 
 export const Default = args => {
-  const { open, colorScheme, disabled, direction } = args?.['bx-overflow-menu'];
+  const { open, colorScheme, disabled, direction, size } = args?.['bx-overflow-menu'];
   return (
-    <BXOverflowMenu colorScheme={colorScheme} disabled={disabled} open={open}>
+    <BXOverflowMenu colorScheme={colorScheme} disabled={disabled} open={open} size={size}>
       <BXOverflowMenuBody direction={direction}>
         <BXOverflowMenuItem>Option 1</BXOverflowMenuItem>
         <BXOverflowMenuItem>Option 2</BXOverflowMenuItem>

--- a/src/components/overflow-menu/overflow-menu-story-vue.ts
+++ b/src/components/overflow-menu/overflow-menu-story-vue.ts
@@ -14,7 +14,7 @@ export { default } from './overflow-menu-story';
 
 export const Default = args => ({
   template: `
-      <bx-overflow-menu :open="open" :color-scheme="colorScheme" :disabled="disabled" [size]="size">
+      <bx-overflow-menu :open="open" :color-scheme="colorScheme" :disabled="disabled" :size="size">
         <bx-overflow-menu-body :direction="direction">
           <bx-overflow-menu-item>Option 1</bx-overflow-menu-item>
           <bx-overflow-menu-item>Option 2</bx-overflow-menu-item>

--- a/src/components/overflow-menu/overflow-menu-story-vue.ts
+++ b/src/components/overflow-menu/overflow-menu-story-vue.ts
@@ -14,7 +14,7 @@ export { default } from './overflow-menu-story';
 
 export const Default = args => ({
   template: `
-      <bx-overflow-menu :open="open" :color-scheme="colorScheme" :disabled="disabled">
+      <bx-overflow-menu :open="open" :color-scheme="colorScheme" :disabled="disabled" [size]="size">
         <bx-overflow-menu-body :direction="direction">
           <bx-overflow-menu-item>Option 1</bx-overflow-menu-item>
           <bx-overflow-menu-item>Option 2</bx-overflow-menu-item>

--- a/src/components/overflow-menu/overflow-menu-story.ts
+++ b/src/components/overflow-menu/overflow-menu-story.ts
@@ -11,7 +11,7 @@ import { html } from 'lit-element';
 import { boolean, select } from '@storybook/addon-knobs';
 import ifNonNull from '../../globals/directives/if-non-null';
 import { FLOATING_MENU_DIRECTION } from '../floating-menu/floating-menu';
-import { OVERFLOW_MENU_COLOR_SCHEME } from './overflow-menu';
+import { OVERFLOW_MENU_COLOR_SCHEME, OVERFLOW_MENU_SIZE } from './overflow-menu';
 import './overflow-menu-body';
 import './overflow-menu-item';
 import storyDocs from './overflow-menu-story.mdx';
@@ -26,10 +26,16 @@ const directions = {
   [`Top (${FLOATING_MENU_DIRECTION.TOP})`]: FLOATING_MENU_DIRECTION.TOP,
 };
 
+const sizes = {
+  'Regular size': null,
+  [`Small size (${OVERFLOW_MENU_SIZE.SMALL})`]: OVERFLOW_MENU_SIZE.SMALL,
+  [`XL size (${OVERFLOW_MENU_SIZE.EXTRA_LARGE})`]: OVERFLOW_MENU_SIZE.EXTRA_LARGE,
+};
+
 export const Default = args => {
-  const { open, colorScheme, disabled, direction } = args?.['bx-overflow-menu'] ?? {};
+  const { open, colorScheme, disabled, direction, size } = args?.['bx-overflow-menu'] ?? {};
   return html`
-    <bx-overflow-menu ?open="${open}" ?disabled="${disabled}">
+    <bx-overflow-menu ?open="${open}" ?disabled="${disabled}" size="${size}">
       <bx-overflow-menu-body color-scheme="${ifNonNull(colorScheme)}" direction="${ifNonNull(direction)}">
         <bx-overflow-menu-item>Option 1</bx-overflow-menu-item>
         <bx-overflow-menu-item>Option 2</bx-overflow-menu-item>
@@ -53,6 +59,7 @@ export default {
         colorScheme: select('Color scheme (color-scheme)', colorSchemes, null),
         disabled: boolean('Disabled (disabled)', false),
         direction: select('Direction (direction in <bx-overflow-menu-body>)', directions, FLOATING_MENU_DIRECTION.BOTTOM),
+        size: select('Overflow menu size (size)', sizes, null),
       }),
     },
   },

--- a/src/components/overflow-menu/overflow-menu.scss
+++ b/src/components/overflow-menu/overflow-menu.scss
@@ -13,6 +13,16 @@ $css--plex: true !default;
   @extend .#{$prefix}--overflow-menu;
 }
 
+:host(#{$prefix}-overflow-menu)[size='sm'] {
+  width: rem(32px);
+  height: rem(32px);
+}
+
+:host(#{$prefix}-overflow-menu)[size='xl'] {
+  width: rem(48px);
+  height: rem(48px);
+}
+
 :host(#{$prefix}-overflow-menu[disabled]) {
   cursor: not-allowed;
 

--- a/src/components/overflow-menu/overflow-menu.scss
+++ b/src/components/overflow-menu/overflow-menu.scss
@@ -14,13 +14,11 @@ $css--plex: true !default;
 }
 
 :host(#{$prefix}-overflow-menu)[size='sm'] {
-  width: rem(32px);
-  height: rem(32px);
+  @extend .#{$prefix}--overflow-menu--sm;
 }
 
 :host(#{$prefix}-overflow-menu)[size='xl'] {
-  width: rem(48px);
-  height: rem(48px);
+  @extend .#{$prefix}--overflow-menu--xl;
 }
 
 :host(#{$prefix}-overflow-menu[disabled]) {

--- a/src/components/overflow-menu/overflow-menu.ts
+++ b/src/components/overflow-menu/overflow-menu.ts
@@ -15,11 +15,11 @@ import FocusMixin from '../../globals/mixins/focus';
 import HostListenerMixin from '../../globals/mixins/host-listener';
 import { find } from '../../globals/internal/collection-helpers';
 import BXFloatingMenuTrigger from '../floating-menu/floating-menu-trigger';
-import { OVERFLOW_MENU_COLOR_SCHEME } from './defs';
+import { OVERFLOW_MENU_COLOR_SCHEME, OVERFLOW_MENU_SIZE } from './defs';
 import BXOverflowMenuBody from './overflow-menu-body';
 import styles from './overflow-menu.scss';
 
-export { OVERFLOW_MENU_COLOR_SCHEME };
+export { OVERFLOW_MENU_COLOR_SCHEME, OVERFLOW_MENU_SIZE };
 
 const { prefix } = settings;
 
@@ -85,6 +85,12 @@ class BXOverflowMenu extends HostListenerMixin(FocusMixin(LitElement)) implement
    */
   @property({ type: Boolean, reflect: true })
   open = false;
+
+  /**
+   * Overflow menu size.
+   */
+  @property({ reflect: true })
+  size = OVERFLOW_MENU_SIZE.REGULAR;
 
   /**
    * @returns The position of the trigger button in the viewport.


### PR DESCRIPTION
### Related Ticket(s)

#533 

### Description

This adds size variants to `overflow-menu`.

### Changelog

**New**

- `sm` and `xl` sizes

