### PR TITLE
feat(content-switcher): add size variants

### DIFF
--- a/src/components/content-switcher/content-switcher-story-angular.ts
+++ b/src/components/content-switcher/content-switcher-story-angular.ts
@@ -17,6 +17,7 @@ export const Default = args => ({
       [value]="value"
       (bx-content-switcher-beingselected)="handleBeforeSelect($event)"
       (bx-content-switcher-selected)="handleAfterSelect($event)"
+      [size]="size"
     >
       <bx-content-switcher-item value="all">Option 1</bx-content-switcher-item>
       <bx-content-switcher-item value="cloudFoundry" disabled>Option 2</bx-content-switcher-item>

--- a/src/components/content-switcher/content-switcher-story-react.tsx
+++ b/src/components/content-switcher/content-switcher-story-react.tsx
@@ -19,7 +19,7 @@ import { Default as baseDefault } from './content-switcher-story';
 export { default } from './content-switcher-story';
 
 export const Default = args => {
-  const { value, disableSelection, onBeforeSelect, onSelect } = args?.['bx-content-switcher'];
+  const { value, disableSelection, onBeforeSelect, onSelect, size } = args?.['bx-content-switcher'];
   const handleBeforeSelected = (event: CustomEvent) => {
     onBeforeSelect(event);
     if (disableSelection) {
@@ -27,7 +27,7 @@ export const Default = args => {
     }
   };
   return (
-    <BXContentSwitcher value={value} onBeforeSelect={handleBeforeSelected} onSelect={onSelect}>
+    <BXContentSwitcher value={value} onBeforeSelect={handleBeforeSelected} onSelect={onSelect} size={size}>
       <BXContentSwitcherItem value="all">Option 1</BXContentSwitcherItem>
       <BXContentSwitcherItem value="cloudFoundry" disabled>
         Option 2

--- a/src/components/content-switcher/content-switcher-story-vue.ts
+++ b/src/components/content-switcher/content-switcher-story-vue.ts
@@ -34,6 +34,7 @@ export const Default = args => {
         :value="value"
         @bx-content-switcher-beingselected="handleBeforeSelect"
         @bx-content-switcher-selected="handleAfterSelect"
+        :size="size"
       >
         <bx-content-switcher-item value="all">Option 1</bx-content-switcher-item>
         <bx-content-switcher-item value="cloudFoundry" disabled>Option 2</bx-content-switcher-item>

--- a/src/components/content-switcher/content-switcher-story.ts
+++ b/src/components/content-switcher/content-switcher-story.ts
@@ -9,17 +9,23 @@
 
 import { html } from 'lit-element';
 import { action } from '@storybook/addon-actions';
-import { boolean } from '@storybook/addon-knobs';
+import { boolean, select } from '@storybook/addon-knobs';
 import textNullable from '../../../.storybook/knob-text-nullable';
 import ifNonNull from '../../globals/directives/if-non-null';
-import './content-switcher';
+import { CONTENT_SWITCHER_SIZE } from './content-switcher';
 import './content-switcher-item';
 import storyDocs from './content-switcher-story.mdx';
 
 const noop = () => {};
 
+const sizes = {
+  'Regular size': null,
+  [`Small size (${CONTENT_SWITCHER_SIZE.SMALL})`]: CONTENT_SWITCHER_SIZE.SMALL,
+  [`XL size (${CONTENT_SWITCHER_SIZE.EXTRA_LARGE})`]: CONTENT_SWITCHER_SIZE.EXTRA_LARGE,
+};
+
 export const Default = args => {
-  const { value, disableSelection, onBeforeSelect = noop, onSelect = noop } = args?.['bx-content-switcher'] ?? {};
+  const { value, disableSelection, onBeforeSelect = noop, onSelect = noop, size } = args?.['bx-content-switcher'] ?? {};
   const handleBeforeSelected = (event: CustomEvent) => {
     onBeforeSelect(event);
     if (disableSelection) {
@@ -31,6 +37,7 @@ export const Default = args => {
       value="${ifNonNull(value)}"
       @bx-content-switcher-beingselected="${handleBeforeSelected}"
       @bx-content-switcher-selected="${onSelect}"
+      size="${size}"
     >
       <bx-content-switcher-item value="all">Option 1</bx-content-switcher-item>
       <bx-content-switcher-item value="cloudFoundry" disabled>Option 2</bx-content-switcher-item>
@@ -50,6 +57,7 @@ export default {
     knobs: {
       'bx-content-switcher': () => ({
         value: textNullable('The value of the selected item (value)', ''),
+        size: select('Button size (size)', sizes, null),
         disableSelection: boolean(
           'Disable user-initiated selection change (Call event.preventDefault() in bx-content-switcher-beingselected event)',
           false

--- a/src/components/content-switcher/content-switcher.scss
+++ b/src/components/content-switcher/content-switcher.scss
@@ -1,5 +1,5 @@
 //
-// Copyright IBM Corp. 2019
+// Copyright IBM Corp. 2019, 2020
 //
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
@@ -11,6 +11,14 @@ $css--plex: true !default;
 
 :host(#{$prefix}-content-switcher) {
   @extend .#{$prefix}--content-switcher;
+}
+
+:host(#{$prefix}-content-switcher[size='sm']) {
+  height: rem(32px);
+}
+
+:host(#{$prefix}-content-switcher[size='xl']) {
+  height: rem(48px);
 }
 
 :host(#{$prefix}-content-switcher-item) {

--- a/src/components/content-switcher/content-switcher.scss
+++ b/src/components/content-switcher/content-switcher.scss
@@ -14,11 +14,11 @@ $css--plex: true !default;
 }
 
 :host(#{$prefix}-content-switcher[size='sm']) {
-  height: rem(32px);
+  @extend .#{$prefix}--content-switcher--sm;
 }
 
 :host(#{$prefix}-content-switcher[size='xl']) {
-  height: rem(48px);
+  @extend .#{$prefix}--content-switcher--xl;
 }
 
 :host(#{$prefix}-content-switcher-item) {

--- a/src/components/content-switcher/content-switcher.ts
+++ b/src/components/content-switcher/content-switcher.ts
@@ -10,11 +10,11 @@
 import { html, property, customElement, LitElement } from 'lit-element';
 import settings from 'carbon-components/es/globals/js/settings';
 import { forEach, indexOf } from '../../globals/internal/collection-helpers';
-import { NAVIGATION_DIRECTION } from './defs';
+import { NAVIGATION_DIRECTION, CONTENT_SWITCHER_SIZE } from './defs';
 import BXSwitch from './content-switcher-item';
 import styles from './content-switcher.scss';
 
-export { NAVIGATION_DIRECTION };
+export { NAVIGATION_DIRECTION, CONTENT_SWITCHER_SIZE };
 
 const { prefix } = settings;
 
@@ -149,6 +149,12 @@ class BXContentSwitcher extends LitElement {
    */
   @property({ reflect: true })
   value = '';
+
+  /**
+   * Content switcher size.
+   */
+  @property({ reflect: true })
+  size = CONTENT_SWITCHER_SIZE.REGULAR;
 
   shouldUpdate(changedProperties) {
     if (changedProperties.has('value')) {

--- a/src/components/content-switcher/defs.ts
+++ b/src/components/content-switcher/defs.ts
@@ -16,3 +16,23 @@ export const NAVIGATION_DIRECTION = {
   Right: 1,
   ArrowRight: 1,
 };
+
+/**
+ * Button size.
+ */
+export enum CONTENT_SWITCHER_SIZE {
+  /**
+   * Regular size.
+   */
+  REGULAR = '',
+
+  /**
+   * Small size.
+   */
+  SMALL = 'sm',
+
+  /**
+   * X-Large size.
+   */
+  EXTRA_LARGE = 'xl',
+}


### PR DESCRIPTION
### Related Ticket(s)

#528  

### Description

This adds size variants to `content-switcher`.

### Changelog

**New**

- `sm` and `xl` sizes

