### PR TITLE
fix(unordered-list): workaround for WebKit

### DIFF
--- a/src/components/list/list.scss
+++ b/src/components/list/list.scss
@@ -29,6 +29,14 @@ $css--plex: true !default;
   }
 }
 
+:host(#{$prefix}-unordered-list) {
+  --#{$prefix}-ce--list-marker: '\002013'; // – en dash
+
+  &[slot='nested'] {
+    --#{$prefix}-ce--list-marker: '\0025AA'; // ▪ square
+  }
+}
+
 :host(#{$prefix}-unordered-list) ::slotted(#{$prefix}-list-item) {
   position: relative;
 
@@ -48,6 +56,14 @@ $css--plex: true !default;
   display: list-item;
   color: $text-01;
   margin-bottom: $carbon--spacing-02;
+
+  &::before {
+    // Workaround for https://bugs.webkit.org/show_bug.cgi?id=178237.
+    // For non-WebKit browsers, `:host(#{$prefix}-unordered-list) ::slotted(#{$prefix}-list-item)` takes this over.
+    position: absolute;
+    left: -$carbon--spacing-05;
+    content: var(--#{$prefix}-ce--list-marker, none);
+  }
 
   .#{$prefix}-ce--list__item__nested-child {
     padding-top: $carbon--spacing-02;


### PR DESCRIPTION
### Description

This change works around a limitation in WebKit where `::before` pseudo element is not supported on `::slotted()` pseudo element.

Refs https://bugs.webkit.org/show_bug.cgi?id=178237.
Refs carbon-design-system/carbon-for-ibm-dotcom#4733.

### Changelog

**New**

- A workaround for a limitation in WebKit where `::before` pseudo element is not supported on `::slotted()` pseudo element.