### PR TITLE
fix(side-nav): fix icon color

### DIFF
--- a/src/components/ui-shell/side-nav.scss
+++ b/src/components/ui-shell/side-nav.scss
@@ -59,8 +59,12 @@ $css--plex: true !default;
   width: auto;
   height: auto;
 
-  .#{$prefix}--side-nav__icon[hidden] {
-    display: none;
+  .#{$prefix}--side-nav__icon {
+    color: $shell-side-nav-text-01;
+
+    &[hidden] {
+      display: none;
+    }
   }
 }
 


### PR DESCRIPTION
### Related Ticket(s)

Refs #564.

### Description

Fixes icon color in `<bx-side-nav-link>` by explicitly setting the color.

### Changelog

**Changed**

- A fix to icon color in `<bx-side-nav-link>`.