### PR TITLE
fix(select): set option text so it is visible in mobile

### DIFF
--- a/src/components/select/select.ts
+++ b/src/components/select/select.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020
+ * Copyright IBM Corp. 2020, 2021
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -97,6 +97,7 @@ class BXSelect extends ValidityMixin(FormMixin(LitElement)) {
                   ?selected="${selected}"
                   value="${ifNonNull(value)}"
                 >
+                  ${ifNonNull(textContent)}
                 </option>
               `
             : html`


### PR DESCRIPTION
### Related Ticket(s)

{{Provide url(s) to the related ticket(s) that this pull request addresses}}

### Description

Need to pass in the Option text as a child in order for it to be viewed in the native select on mobile

BEFORE:
<img width="409" alt="Screen Shot 2021-01-13 at 5 48 56 PM" src="https://user-images.githubusercontent.com/54281166/104519653-c791b500-55c7-11eb-8100-b90e61b321ec.png">

NOW:
<img width="413" alt="Screen Shot 2021-01-13 at 5 49 33 PM" src="https://user-images.githubusercontent.com/54281166/104519660-cb253c00-55c7-11eb-8230-bb997fa75cbf.png">

### Changelog

**New**

- {{new thing}}

**Changed**

- {{changed thing}}

**Removed**

- {{removed thing}}
