### PR TITLE
fix(dropdown): improved JAWS accessibility to read options

### DIFF
--- a/src/components/combo-box/combo-box.scss
+++ b/src/components/combo-box/combo-box.scss
@@ -1,5 +1,5 @@
 //
-// Copyright IBM Corp. 2019, 2020
+// Copyright IBM Corp. 2019, 2021
 //
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
@@ -84,6 +84,7 @@ $css--plex: true !default;
 
 :host(#{$prefix}-combo-box-item[highlighted]) {
   @extend .#{$prefix}--list-box__menu-item--highlighted;
+  outline: none;
 }
 
 :host(#{$prefix}-combo-box-item[selected]) {

--- a/src/components/dropdown/dropdown-item.ts
+++ b/src/components/dropdown/dropdown-item.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019, 2020
+ * Copyright IBM Corp. 2019, 2021
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -54,6 +54,12 @@ class BXDropdownItem extends LitElement {
    */
   @property()
   value = '';
+
+  updated(changedProperties) {
+    if (changedProperties.has('highlighted')) {
+      this.setAttribute('tabindex', `${this.highlighted ? 0 : -1}`);
+    }
+  }
 
   render() {
     const { selected } = this;

--- a/src/components/dropdown/dropdown.scss
+++ b/src/components/dropdown/dropdown.scss
@@ -1,5 +1,5 @@
 //
-// Copyright IBM Corp. 2019, 2020
+// Copyright IBM Corp. 2019, 2021
 //
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
@@ -69,6 +69,7 @@ $css--plex: true !default;
 
 :host(#{$prefix}-dropdown-item[highlighted]) {
   @extend .#{$prefix}--list-box__menu-item--highlighted;
+  outline: none;
 }
 
 :host(#{$prefix}-dropdown-item[selected]) {

--- a/src/components/dropdown/dropdown.ts
+++ b/src/components/dropdown/dropdown.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019, 2020
+ * Copyright IBM Corp. 2019, 2021
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -285,6 +285,9 @@ class BXDropdown extends ValidityMixin(HostListenerMixin(FocusMixin(LitElement))
     }
     forEach(items, (item, i) => {
       (item as BXDropdownItem).highlighted = i === nextIndex;
+      if (i === nextIndex) {
+        (item as HTMLElement).focus();
+      }
     });
 
     const nextItem = items[nextIndex];


### PR DESCRIPTION
### Related Ticket(s)

[Carbon for IBM.com #4489](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues/4889)

### Description

The Web Component version of Carbon for IBM.com's [Footer - Language Selection](https://ibmdotcom-web-components-canary.mybluemix.net/?path=/story/components-footer--default-language-only) had an accessibility issue using JAWS screen read that made it unable to fully read out the options presented in the listbox, sometimes not even reading anything.

Since the component extends from ComboBox, which ultimately extends from Dropdown, this PR addresses the bug in that component. 

Functionality remains the same.

### Changelog

**New**

- `outline: none` in `combo-box.scss` and `dropdown.scss` to avoid focus outline when item is highlighted

**Changed**

- `tabindex` changes from `-1` to `0` if `dropdown-item` is highlighted
- `dropdown-item` focused upon activation of highlight state

