### PR TITLE
fix(data-table): corrected tabbing into proper bars

### DIFF
--- a/src/components/data-table/table-batch-actions.ts
+++ b/src/components/data-table/table-batch-actions.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019, 2020
+ * Copyright IBM Corp. 2019, 2021
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -46,6 +46,12 @@ class BXTableBatchActions extends LitElement {
    */
   @property({ type: Number, attribute: 'selected-rows-count' })
   selectedRowsCount = 0;
+
+  updated(changedProperties) {
+    if (changedProperties.has('active')) {
+      this.setAttribute('tabindex', `${this.active ? 0 : -1}`);
+    }
+  }
 
   render() {
     const { formatSelectedItemsCount, selectedRowsCount, _handleCancel: handleCancel } = this;

--- a/src/components/data-table/table-batch-actions.ts
+++ b/src/components/data-table/table-batch-actions.ts
@@ -49,7 +49,7 @@ class BXTableBatchActions extends LitElement {
 
   updated(changedProperties) {
     if (changedProperties.has('active')) {
-      this.setAttribute('tabindex', `${this.active ? 0 : -1}`);
+      this.setAttribute('tabindex', `${this.active ? '' : '-1'}`);
     }
   }
 

--- a/src/components/data-table/table-toolbar-content.ts
+++ b/src/components/data-table/table-toolbar-content.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019, 2020
+ * Copyright IBM Corp. 2019, 2021
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -24,6 +24,12 @@ class BXTableToolbarContent extends LitElement {
    */
   @property({ type: Boolean, reflect: true, attribute: 'has-batch-actions' })
   hasBatchActions = false;
+
+  updated(changedProperties) {
+    if (changedProperties.has('hasBatchActions')) {
+      this.setAttribute('tabindex', `${this.hasBatchActions ? -1 : 0}`);
+    }
+  }
 
   render() {
     return html`

--- a/src/components/data-table/table-toolbar-content.ts
+++ b/src/components/data-table/table-toolbar-content.ts
@@ -27,7 +27,7 @@ class BXTableToolbarContent extends LitElement {
 
   updated(changedProperties) {
     if (changedProperties.has('hasBatchActions')) {
-      this.setAttribute('tabindex', `${this.hasBatchActions ? -1 : 0}`);
+      this.setAttribute('tabindex', `${this.hasBatchActions ? '-1' : ''}`);
     }
   }
 


### PR DESCRIPTION
### Related Ticket(s)
#467

### Description

Tabbing now focuses on the action bar that is currently displayed. Before the change, continuous tabbing kept focusing on the bar that was hidden, which effectively 'hid' the proper bar from view.

### Changelog

**Changed**

- `tabIndex` toggles on each action bar depending on which one is being shown
