### PR TITLE
fix(header-menu): remove menu role from ul for better accessibility

### DIFF
--- a/src/components/ui-shell/header-menu.ts
+++ b/src/components/ui-shell/header-menu.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019, 2020
+ * Copyright IBM Corp. 2019, 2021
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -130,7 +130,7 @@ class BXHeaderMenu extends HostListenerMixin(FocusMixin(LitElement)) {
       >
         ${triggerContent}${ChevronDownGlyph({ part: 'trigger-icon', class: `${prefix}--header__menu-arrow` })}
       </a>
-      <ul role="menu" part="menu-body" class="${prefix}--header__menu" aria-label="${ifDefined(menuLabel)}">
+      <ul part="menu-body" class="${prefix}--header__menu" aria-label="${ifDefined(menuLabel)}">
         <slot></slot>
       </ul>
     `;

--- a/tests/snapshots/ui-shell.md
+++ b/tests/snapshots/ui-shell.md
@@ -62,7 +62,6 @@
 <ul
   class="bx--header__menu"
   part="menu-body"
-  role="menu"
 >
   <slot>
   </slot>
@@ -88,7 +87,6 @@
   aria-label="menu-label-foo"
   class="bx--header__menu"
   part="menu-body"
-  role="menu"
 >
   <slot>
   </slot>


### PR DESCRIPTION
### Related Ticket(s)

{{Provide url(s) to the related ticket(s) that this pull request addresses}}

### Description

This PR removes the `role='menu'` from the `ul` as it is unnecessary and conflicts with the elements placed in the megamenu/dropdown.

PR here from carbon-for-ibm-dotcom where we removed the menu role from our own version of the header menu
https://github.com/carbon-design-system/carbon-for-ibm-dotcom/pull/4624

The dropdown menu/megamenu shouldn't have the role="menu" applied as listed here:
Example Disclosure for Navigation Menus | WAI-ARIA Authoring Practices 1.1
https://www.w3.org/TR/wai-aria-practices/examples/disclosure/disclosure-navigation.html

<img width="950" alt="Screen Shot 2020-12-03 at 4 25 20 PM" src="https://user-images.githubusercontent.com/54281166/101090282-661c0680-3584-11eb-8dd0-b43ca6f9aa7e.png">

### Changelog

**Removed**

- role=menu
