### PR TITLE
chore(devenv): fix JS error in the Docs tab of skeleton text

### DIFF
--- a/src/components/file-uploader/file-uploader-story.mdx
+++ b/src/components/file-uploader/file-uploader-story.mdx
@@ -1,0 +1,19 @@
+import { Preview, Props, Story } from '@storybook/addon-docs/blocks';
+
+# File uploader
+
+File uploaders allow users to select one or more files to upload to a specific location.
+
+<Preview withToolbar>
+  <Story id="components-file-uploader--default" height="200px" />
+</Preview>
+
+## `<bx-file-uploader>` attributes, properties and events
+
+<Props of="bx-file-uploader" />
+
+## `<bx-file-uploader-item>` attributes, properties and events
+
+Note: For `boolean` attributes, `true` means simply setting the attribute (e.g. `<bx-file-uploader-item invalid>`) and `false` means not setting the attribute (e.g. `<bx-file-uploader-item>` without `invalid` attribute).
+
+<Props of="bx-file-uploader-item" />

--- a/src/components/file-uploader/file-uploader-story.ts
+++ b/src/components/file-uploader/file-uploader-story.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019, 2020
+ * Copyright IBM Corp. 2019, 2021
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -17,6 +17,7 @@ import './drop-container';
 import { FILE_UPLOADER_ITEM_SIZE, FILE_UPLOADER_ITEM_STATE } from './file-uploader-item';
 import textNullable from '../../../.storybook/knob-text-nullable';
 import { FileData } from './stories/types';
+import storyDocs from './file-uploader-story.mdx';
 
 const sizes = {
   'Regular size': null,
@@ -243,6 +244,7 @@ Default.storyName = 'Default';
 export default {
   title: 'Components/File uploader',
   parameters: {
+    ...storyDocs.parameters,
     knobs: {
       'bx-file-uploader': () => ({
         helperText: textNullable('Helper text (helper-text)', 'Only .jpg and .png files. 500kb max file size'),

--- a/src/components/select/select-story.mdx
+++ b/src/components/select/select-story.mdx
@@ -1,0 +1,27 @@
+import { Preview, Props, Story } from '@storybook/addon-docs/blocks';
+
+# Select
+
+The select component allows users to choose one option from a list. It is used in forms for users to submit data.
+
+<Preview withToolbar>
+  <Story id="components-select--default" height="200px" />
+</Preview>
+
+## `<bx-select>` attributes, properties and events
+
+Note: For `boolean` attributes, `true` means simply setting the attribute (e.g. `<bx-select autofocus>`) and `false` means not setting the attribute (e.g. `<bx-select>` without `autofocus` attribute).
+
+<Props of="bx-select-item" />
+
+## `<bx-select-item-group>` attributes, properties and events
+
+Note: For `boolean` attributes, `true` means simply setting the attribute (e.g. `<bx-select-item-group disabled>`) and `false` means not setting the attribute (e.g. `<bx-select-item-group>` without `disabled` attribute).
+
+<Props of="bx-select-item-group" />
+
+## `<bx-select-item>` attributes, properties and events
+
+Note: For `boolean` attributes, `true` means simply setting the attribute (e.g. `<bx-select-item disabled>`) and `false` means not setting the attribute (e.g. `<bx-select-item>` without `disabled` attribute).
+
+<Props of="bx-select-item" />

--- a/src/components/select/select-story.ts
+++ b/src/components/select/select-story.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020
+ * Copyright IBM Corp. 2020, 2021
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -17,6 +17,7 @@ import textNullable from '../../../.storybook/knob-text-nullable';
 import ifNonNull from '../../globals/directives/if-non-null';
 import { INPUT_COLOR_SCHEME, INPUT_SIZE } from '../input/input';
 import './select';
+import storyDocs from './select-story.mdx';
 
 const colorSchemes = {
   [`Regular`]: null,
@@ -94,4 +95,7 @@ Default.parameters = {
 
 export default {
   title: 'Components/Select',
+  parameters: {
+    ...storyDocs.parameters,
+  },
 };

--- a/src/components/skeleton-text/skeleton-text-story.ts
+++ b/src/components/skeleton-text/skeleton-text-story.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019, 2020
+ * Copyright IBM Corp. 2019, 2021
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -54,9 +54,6 @@ export default {
     ...storyDocs.parameters,
     percy: {
       skip: true,
-    },
-    docs: {
-      page: storyDocs,
     },
   },
 };


### PR DESCRIPTION
### Related Ticket(s)

Refs #602.

### Description

Fixes JavaScript error in the Docs tab of the story of `<bx-skeleton-text>`. Also adds Docs tab code for
`<bx-file-uploader>` and `<bx-select>`.

### Changelog

**New**

- Docs tab code for `<bx-file-uploader>` and `<bx-select>`.

**Changed**

- Fixes JavaScript error in the Docs tab of the story of `<bx-skeleton-text>`.