### PR TITLE
feat(content-switcher): add light variant

### DIFF
--- a/src/components/content-switcher/content-switcher-item.ts
+++ b/src/components/content-switcher/content-switcher-item.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019, 2020
+ * Copyright IBM Corp. 2019, 2021
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -12,6 +12,7 @@ import { html, property, customElement, LitElement } from 'lit-element';
 import settings from 'carbon-components/es/globals/js/settings';
 import ifNonNull from '../../globals/directives/if-non-null';
 import FocusMixin from '../../globals/mixins/focus';
+import { CONTENT_SWITCHER_COLOR_SCHEME } from './defs';
 import styles from './content-switcher.scss';
 
 const { prefix } = settings;
@@ -22,6 +23,12 @@ const { prefix } = settings;
  */
 @customElement(`${prefix}-content-switcher-item`)
 class BXContentSwitcherItem extends FocusMixin(LitElement) {
+  /**
+   * The color scheme.
+   */
+  @property({ attribute: 'color-scheme', reflect: true })
+  colorScheme = CONTENT_SWITCHER_COLOR_SCHEME.REGULAR;
+
   /**
    * `true` if this content switcher item should be disabled.
    */

--- a/src/components/content-switcher/content-switcher-story-angular.ts
+++ b/src/components/content-switcher/content-switcher-story-angular.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019, 2020
+ * Copyright IBM Corp. 2019, 2021
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -14,6 +14,7 @@ import baseStory, { Default as baseDefault } from './content-switcher-story';
 export const Default = args => ({
   template: `
     <bx-content-switcher
+      [colorScheme]="colorScheme"
       [value]="value"
       (bx-content-switcher-beingselected)="handleBeforeSelect($event)"
       (bx-content-switcher-selected)="handleAfterSelect($event)"

--- a/src/components/content-switcher/content-switcher-story-react.tsx
+++ b/src/components/content-switcher/content-switcher-story-react.tsx
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019, 2020
+ * Copyright IBM Corp. 2019, 2021
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -19,7 +19,7 @@ import { Default as baseDefault } from './content-switcher-story';
 export { default } from './content-switcher-story';
 
 export const Default = args => {
-  const { value, disableSelection, onBeforeSelect, onSelect, size } = args?.['bx-content-switcher'];
+  const { colorScheme, value, disableSelection, onBeforeSelect, onSelect, size } = args?.['bx-content-switcher'];
   const handleBeforeSelected = (event: CustomEvent) => {
     onBeforeSelect(event);
     if (disableSelection) {
@@ -27,7 +27,12 @@ export const Default = args => {
     }
   };
   return (
-    <BXContentSwitcher value={value} onBeforeSelect={handleBeforeSelected} onSelect={onSelect} size={size}>
+    <BXContentSwitcher
+      colorScheme={colorScheme}
+      value={value}
+      onBeforeSelect={handleBeforeSelected}
+      onSelect={onSelect}
+      size={size}>
       <BXContentSwitcherItem value="all">Option 1</BXContentSwitcherItem>
       <BXContentSwitcherItem value="cloudFoundry" disabled>
         Option 2

--- a/src/components/content-switcher/content-switcher-story-vue.ts
+++ b/src/components/content-switcher/content-switcher-story-vue.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019, 2020
+ * Copyright IBM Corp. 2019, 2021
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -31,6 +31,7 @@ export const Default = args => {
   return {
     template: `
       <bx-content-switcher
+        :color-scheme="colorScheme"
         :value="value"
         @bx-content-switcher-beingselected="handleBeforeSelect"
         @bx-content-switcher-selected="handleAfterSelect"

--- a/src/components/content-switcher/content-switcher-story.ts
+++ b/src/components/content-switcher/content-switcher-story.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019, 2020
+ * Copyright IBM Corp. 2019, 2021
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -12,11 +12,16 @@ import { action } from '@storybook/addon-actions';
 import { boolean, select } from '@storybook/addon-knobs';
 import textNullable from '../../../.storybook/knob-text-nullable';
 import ifNonNull from '../../globals/directives/if-non-null';
-import { CONTENT_SWITCHER_SIZE } from './content-switcher';
+import { CONTENT_SWITCHER_COLOR_SCHEME, CONTENT_SWITCHER_SIZE } from './content-switcher';
 import './content-switcher-item';
 import storyDocs from './content-switcher-story.mdx';
 
 const noop = () => {};
+
+const colorSchemes = {
+  [`Regular`]: null,
+  [`Light (${CONTENT_SWITCHER_COLOR_SCHEME.LIGHT})`]: CONTENT_SWITCHER_COLOR_SCHEME.LIGHT,
+};
 
 const sizes = {
   'Regular size': null,
@@ -25,7 +30,8 @@ const sizes = {
 };
 
 export const Default = args => {
-  const { value, disableSelection, onBeforeSelect = noop, onSelect = noop, size } = args?.['bx-content-switcher'] ?? {};
+  const { colorScheme, value, disableSelection, onBeforeSelect = noop, onSelect = noop, size } =
+    args?.['bx-content-switcher'] ?? {};
   const handleBeforeSelected = (event: CustomEvent) => {
     onBeforeSelect(event);
     if (disableSelection) {
@@ -34,6 +40,7 @@ export const Default = args => {
   };
   return html`
     <bx-content-switcher
+      color-scheme="${ifNonNull(colorScheme)}"
       value="${ifNonNull(value)}"
       @bx-content-switcher-beingselected="${handleBeforeSelected}"
       @bx-content-switcher-selected="${onSelect}"
@@ -56,6 +63,7 @@ export default {
     ...storyDocs.parameters,
     knobs: {
       'bx-content-switcher': () => ({
+        colorScheme: select('Color scheme (color-scheme)', colorSchemes, null),
         value: textNullable('The value of the selected item (value)', ''),
         size: select('Button size (size)', sizes, null),
         disableSelection: boolean(

--- a/src/components/content-switcher/content-switcher.scss
+++ b/src/components/content-switcher/content-switcher.scss
@@ -1,5 +1,5 @@
 //
-// Copyright IBM Corp. 2019, 2020
+// Copyright IBM Corp. 2019, 2021
 //
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
@@ -43,12 +43,35 @@ $css--plex: true !default;
       z-index: 2;
       left: 0;
     }
+  }
 
-    &.#{$prefix}--content-switcher--selected,
-    &:focus,
-    &:hover {
+  &[color-scheme='light'] {
+    .#{$prefix}--content-switcher-btn {
+      background-color: $ui-02;
+
+      &:hover {
+        background-color: $hover-light-ui;
+      }
+
       &::before {
-        background-color: transparent;
+        background-color: $decorative-01;
+      }
+
+      &.#{$prefix}--content-switcher--selected {
+        background-color: $ui-05;
+      }
+    }
+  }
+
+  &,
+  &[color-scheme='light'] {
+    .#{$prefix}--content-switcher-btn {
+      &.#{$prefix}--content-switcher--selected,
+      &:focus,
+      &:hover {
+        &::before {
+          background-color: transparent;
+        }
       }
     }
   }

--- a/src/components/content-switcher/content-switcher.ts
+++ b/src/components/content-switcher/content-switcher.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019, 2020
+ * Copyright IBM Corp. 2019, 2021
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -10,11 +10,11 @@
 import { html, property, customElement, LitElement } from 'lit-element';
 import settings from 'carbon-components/es/globals/js/settings';
 import { forEach, indexOf } from '../../globals/internal/collection-helpers';
-import { NAVIGATION_DIRECTION, CONTENT_SWITCHER_SIZE } from './defs';
+import { NAVIGATION_DIRECTION, CONTENT_SWITCHER_COLOR_SCHEME, CONTENT_SWITCHER_SIZE } from './defs';
 import BXSwitch from './content-switcher-item';
 import styles from './content-switcher.scss';
 
-export { NAVIGATION_DIRECTION, CONTENT_SWITCHER_SIZE };
+export { NAVIGATION_DIRECTION, CONTENT_SWITCHER_COLOR_SCHEME, CONTENT_SWITCHER_SIZE };
 
 const { prefix } = settings;
 
@@ -145,6 +145,12 @@ class BXContentSwitcher extends LitElement {
   }
 
   /**
+   * The color scheme.
+   */
+  @property({ attribute: 'color-scheme', reflect: true })
+  colorScheme = CONTENT_SWITCHER_COLOR_SCHEME.REGULAR;
+
+  /**
    * The value of the selected item.
    */
   @property({ reflect: true })
@@ -164,6 +170,15 @@ class BXContentSwitcher extends LitElement {
       });
     }
     return true;
+  }
+
+  updated(changedProperties) {
+    if (changedProperties.has('colorScheme')) {
+      // Propagate `color-scheme` attribute to descendants until `:host-context()` gets supported in all major browsers
+      forEach(this.querySelectorAll((this.constructor as typeof BXContentSwitcher).selectorItem), elem => {
+        elem.setAttribute('color-scheme', this.colorScheme);
+      });
+    }
   }
 
   /**

--- a/src/components/content-switcher/defs.ts
+++ b/src/components/content-switcher/defs.ts
@@ -1,11 +1,13 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020
+ * Copyright IBM Corp. 2020, 2021
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
+
+export { FORM_ELEMENT_COLOR_SCHEME as CONTENT_SWITCHER_COLOR_SCHEME } from '../../globals/shared-enums';
 
 /**
  * Navigation direction, associated with key symbols.

--- a/src/components/tabs/defs.ts
+++ b/src/components/tabs/defs.ts
@@ -7,7 +7,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-export { FORM_ELEMENT_COLOR_SCHEME as TABS_COLOR_SCHEME } from '../../globals/shared-enums';
+export { CONTENT_SWITCHER_COLOR_SCHEME as TABS_COLOR_SCHEME } from '../content-switcher/defs';
 
 /**
  * Navigation direction for narrow mode, associated with key symbols.


### PR DESCRIPTION
### Related Ticket(s)

Refs #444.

### Changelog

**New**

- `color-scheme="light"` support to `<bx-content-switcher>`.