### PR TITLE
chore(export): add breadcrumb item and link

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,8 @@ export { default as BXAccordionItem } from './components/accordion/accordion-ite
 export { default as BXButton } from './components/button/button';
 export { default as BXButtonSkeleton } from './components/button/button-skeleton';
 export { default as BXBreadcrumb } from './components/breadcrumb/breadcrumb';
+export { default as BXBreadcrumbItem } from './components/breadcrumb/breadcrumb-item';
+export { default as BXBreadcrumbLink } from './components/breadcrumb/breadcrumb-link';
 export { default as BXCheckbox } from './components/checkbox/checkbox';
 export { default as BXCodeSnippet } from './components/code-snippet/code-snippet';
 export { default as BXCodeSnippetSkeleton } from './components/code-snippet/code-snippet-skeleton';


### PR DESCRIPTION
### Description
This PR adds `BXBreadcrumbItem` & `BXBreadcrumbLink` to exports. 

I'm not sure, maybe be these were intentionally left out? For my use case I am using snowpack and I can easily import other components, but was unable to import `BXBreadcrumbItem` & `BXBreadcrumbLink`.

### Changelog

**New** to `src/index.ts`
- `export { default as BXBreadcrumbItem } from './components/breadcrumb/breadcrumb-item';`
- `export { default as BXBreadcrumbLink } from './components/breadcrumb/breadcrumb-link';`

