### PR TITLE
docs(welcome): updating content regarding framework wrappers

### DIFF
--- a/docs/welcome-story.mdx
+++ b/docs/welcome-story.mdx
@@ -123,12 +123,16 @@ If you just want to try our components for demnstrations and so on, you can use 
 
 ### JavaScript framework integration
 
-Given the nature of `carbon-web-components` built on top of web standard, `carbon-web-components` works well with JavaScript framework of your choice.
-Please follow below links:
+In addition to the available Web Component versions of Carbon components, this
+library also includes framework wrappers for Angular, React, and Vue if the
+desire is to use instead of the pure framework versions of Carbon components.
+This is achievable since Web Components is the modern browser standard, and
+works well with other front-end frameworks that exist in the application. In
+turn, this also comes with the benefits of encapsulation within the Shadow DOM:
 
-- [Angular](https://web-components.carbondesignsystem.com/angular/index.html)
-- [React](https://web-components.carbondesignsystem.com/react/index.html)
-- [Vue](https://web-components.carbondesignsystem.com/vue/index.html)
+- [Angular wrapper for Carbon Web Components](https://web-components.carbondesignsystem.com/angular/index.html)
+- [React wrapper for Carbon Web Components](https://web-components.carbondesignsystem.com/react/index.html)
+- [Vue wrapper for Carbon Web Components](https://web-components.carbondesignsystem.com/vue/index.html)
 
 ### Other usage guides
 


### PR DESCRIPTION
### Related Ticket(s)

No related issue

### Description

This change is in response to the pull request to include documentation
on Carbon Web Components on the carbon design system website. This is to
 clarify the differences between the pure framework libraries, and the
 wrapper versions included with `carbon-web-components`.

### Changelog

**Changed**

- Welcome documentation
