### PR TITLE
fix(combo-box): make X button clear the selection

### DIFF
--- a/src/components/combo-box/combo-box.ts
+++ b/src/components/combo-box/combo-box.ts
@@ -120,8 +120,7 @@ class BXComboBox extends BXDropdown {
     });
     this._filterInputValue = '';
     this._filterInputNode.focus();
-    this.open = false;
-    this.value = '';
+    this._handleUserInitiatedSelectItem();
   }
 
   protected _handleUserInitiatedSelectItem(item?: BXComboBoxItem) {
@@ -139,6 +138,18 @@ class BXComboBox extends BXDropdown {
       this.requestUpdate();
     }
     super._handleUserInitiatedSelectItem(item);
+  }
+
+  protected _selectionDidChange(itemToSelect?: BXComboBoxItem) {
+    this.value = !itemToSelect ? '' : itemToSelect.value;
+    forEach(this.querySelectorAll((this.constructor as typeof BXDropdown).selectorItemSelected), item => {
+      (item as BXComboBoxItem).selected = false;
+    });
+    if (itemToSelect) {
+      itemToSelect.selected = true;
+      this._assistiveStatusText = this.selectedItemAssistiveText;
+    }
+    this._handleUserInitiatedToggle(false);
   }
 
   protected _renderTriggerContent(): TemplateResult {

--- a/src/components/combo-box/combo-box.ts
+++ b/src/components/combo-box/combo-box.ts
@@ -121,7 +121,7 @@ class BXComboBox extends BXDropdown {
     this._filterInputValue = '';
     this._filterInputNode.focus();
     this.open = false;
-    this.requestUpdate();
+    this.value = '';
   }
 
   protected _handleUserInitiatedSelectItem(item?: BXComboBoxItem) {

--- a/tests/karma-setup-renderroot.js
+++ b/tests/karma-setup-renderroot.js
@@ -1,0 +1,22 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2021
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+document.head.insertAdjacentHTML(
+  'afterBegin',
+  `
+    <style>
+      :root, body {
+        margin: 0;
+        padding: 0;
+      }
+    </style>
+  `
+);

--- a/tests/karma.conf.js
+++ b/tests/karma.conf.js
@@ -50,9 +50,12 @@ module.exports = function setupKarma(config) {
       },
     },
 
-    files: ['src/polyfills/index.ts', 'tests/utils/snapshot.js', 'tests/snapshots/**/*.md'].concat(
-      specs.length > 0 ? specs : ['tests/karma-test-shim.js']
-    ),
+    files: [
+      'src/polyfills/index.ts',
+      'tests/utils/snapshot.js',
+      'tests/snapshots/**/*.md',
+      'tests/karma-setup-renderroot.js',
+    ].concat(specs.length > 0 ? specs : ['tests/karma-test-shim.js']),
 
     preprocessors: {
       'src/**/*.[jt]s': ['webpack', 'sourcemap'], // For generatoring coverage report for untested files

--- a/tests/spec/combo-box_spec.ts
+++ b/tests/spec/combo-box_spec.ts
@@ -283,6 +283,7 @@ describe('bx-combo-box', function() {
       expect(inner!.classList.contains('bx--list-box--expanded')).toBe(true);
       (elem.shadowRoot!.querySelector('.bx--list-box__selection') as HTMLElement).click();
       await Promise.resolve();
+      expect((elem as BXComboBox).value).toBe('');
       expect(inputNode.value).toBe('');
       expect(inner!.classList.contains('bx--list-box--expanded')).toBe(false);
       expect(itemNodes[0].hasAttribute('highlighted')).toBe(false);
@@ -290,6 +291,7 @@ describe('bx-combo-box', function() {
       expect(itemNodes[2].hasAttribute('highlighted')).toBe(false);
       expect(itemNodes[3].hasAttribute('highlighted')).toBe(false);
       expect(itemNodes[4].hasAttribute('highlighted')).toBe(false);
+      expect(itemNodes[3].hasAttribute('selected')).toBe(false);
     });
 
     it('Should support clearing the typeahead by space key', async function() {
@@ -303,6 +305,7 @@ describe('bx-combo-box', function() {
       (event as any).key = ' ';
       selectionButton!.dispatchEvent(event);
       await Promise.resolve();
+      expect((elem as BXComboBox).value).toBe('');
       expect(inputNode.value).toBe('');
       expect(inner!.classList.contains('bx--list-box--expanded')).toBe(false);
       expect(itemNodes[0].hasAttribute('highlighted')).toBe(false);
@@ -310,6 +313,7 @@ describe('bx-combo-box', function() {
       expect(itemNodes[2].hasAttribute('highlighted')).toBe(false);
       expect(itemNodes[3].hasAttribute('highlighted')).toBe(false);
       expect(itemNodes[4].hasAttribute('highlighted')).toBe(false);
+      expect(itemNodes[3].hasAttribute('selected')).toBe(false);
     });
 
     it('Should support clearing the typeahead by enter key', async function() {
@@ -323,6 +327,7 @@ describe('bx-combo-box', function() {
       (event as any).key = 'Enter';
       selectionButton!.dispatchEvent(event);
       await Promise.resolve();
+      expect((elem as BXComboBox).value).toBe('');
       expect(inputNode.value).toBe('');
       expect(inner!.classList.contains('bx--list-box--expanded')).toBe(false);
       expect(itemNodes[0].hasAttribute('highlighted')).toBe(false);
@@ -330,6 +335,7 @@ describe('bx-combo-box', function() {
       expect(itemNodes[2].hasAttribute('highlighted')).toBe(false);
       expect(itemNodes[3].hasAttribute('highlighted')).toBe(false);
       expect(itemNodes[4].hasAttribute('highlighted')).toBe(false);
+      expect(itemNodes[3].hasAttribute('selected')).toBe(false);
     });
 
     it('Should support selecting an item after typing', async function() {

--- a/tests/spec/combo-box_spec.ts
+++ b/tests/spec/combo-box_spec.ts
@@ -189,6 +189,24 @@ describe('bx-combo-box', function() {
       expect((elem.shadowRoot!.getElementById('trigger-label') as HTMLInputElement).value).toBe('Option 1');
     });
 
+    it('should provide a way to cancel clearing selection', async function() {
+      events.on(elem, 'bx-combo-box-beingselected', (event: CustomEvent) => {
+        expect(event.detail.item).toBeUndefined();
+        event.preventDefault();
+      });
+      const inner = elem.shadowRoot!.querySelector('div[role="listbox"]');
+      (elem.shadowRoot!.querySelector('.bx--list-box__selection') as HTMLElement).click();
+      await Promise.resolve();
+      expect((elem as BXComboBox).value).toBe('all');
+      expect(inner!.classList.contains('bx--list-box--expanded')).toBe(true);
+      expect(itemNodes[0].hasAttribute('selected')).toBe(true);
+      expect(itemNodes[1].hasAttribute('selected')).toBe(false);
+      expect(itemNodes[2].hasAttribute('selected')).toBe(false);
+      expect(itemNodes[3].hasAttribute('selected')).toBe(false);
+      expect(itemNodes[4].hasAttribute('selected')).toBe(false);
+      expect((elem.shadowRoot!.getElementById('trigger-label') as HTMLInputElement).value).toBe('Option 1');
+    });
+
     it('should reflect the added child to the selection', async function() {
       const itemNode = document.createElement('bx-combo-box-item');
       itemNode.textContent = 'text-added';


### PR DESCRIPTION
### Related Ticket(s)

Refs #620.

### Description

The X button in `<bx-combo-box>` used to merely clear the type-ahead field, which controls which `<bx-combo-box-item>` should be highlighted.

However, X button in the React version clears the selection as well. This change makes such behavior in sync with the React version.

The type-ahead field of `<bx-combo-box>` controls the highlight of `<bx-combo-box-item>`, not selection, and this change keeps such behavior intact. In other words, this change affect only the behavior of the X button.

### Changelog

**Changed**

- X button in `<bx-combo-box>` now clears the selection in addition to the highlight.