### PR TITLE
fix(release): skip bumping the version and committing the release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,6 +29,8 @@ jobs:
         with:
           github-token: ${{ secrets.github_token }}
           release-count: 1
+          skip-version-file: 'true'
+          skip-commit: 'true'
           output-file: "false"
       - name: Create Github Release
         if: steps.publish.outputs.version != steps.publish.outputs['old-version']


### PR DESCRIPTION
### Related Ticket(s)

No related issue

### Description

I noticed in the last publish action that the changelog action was trying to bump the version. This extra config should hopefully skip that step and generate the changelog properly.

### Changelog

**Changed**

- publish.yml
