### PR TITLE
fix(dropdown): added formdata event support

### DIFF
--- a/docs/form-story.mdx
+++ b/docs/form-story.mdx
@@ -1,6 +1,6 @@
 import { Meta } from '@storybook/addon-docs/blocks';
 
-<Meta title="Introduction/Form paticipation" />
+<Meta title="Introduction/Form participation" />
 
 # Having components participate in form
 
@@ -24,7 +24,7 @@ button.addEventListener('click', () => {
   });
   event.formData = formData;
   form.dispatchEvent(event);
-  // Now `formData` is populated with the data in `<bx-input>`, etc. in the `<form>`.
+  // Now `formData` is populated with the data in components such as `<bx-input>` or `<bx-dropdown>`, etc. in the `<form>`.
   // You can use `formData` with `fetch()`/XHR instead of letting `<form>` submit the data
 });
 ```

--- a/src/components/dropdown/dropdown.ts
+++ b/src/components/dropdown/dropdown.ts
@@ -15,6 +15,7 @@ import { html, property, query, customElement, LitElement } from 'lit-element';
 import ChevronDown16 from '@carbon/icons/lib/chevron--down/16';
 import WarningFilled16 from '@carbon/icons/lib/warning--filled/16';
 import FocusMixin from '../../globals/mixins/focus';
+import FormMixin from '../../globals/mixins/form';
 import HostListenerMixin from '../../globals/mixins/host-listener';
 import ValidityMixin from '../../globals/mixins/validity';
 import HostListener from '../../globals/decorators/host-listener';
@@ -45,7 +46,7 @@ const { prefix } = settings;
  * @fires bx-dropdown-toggled - The custom event fired after the open state of this dropdown is toggled upon a user gesture.
  */
 @customElement(`${prefix}-dropdown`)
-class BXDropdown extends ValidityMixin(HostListenerMixin(FocusMixin(LitElement))) {
+class BXDropdown extends ValidityMixin(HostListenerMixin(FormMixin(FocusMixin(LitElement)))) {
   /**
    * The latest status of this dropdown, for screen reader to accounce.
    */
@@ -345,6 +346,18 @@ class BXDropdown extends ValidityMixin(HostListenerMixin(FocusMixin(LitElement))
   /* eslint-enable class-methods-use-this */
 
   /**
+   * Handles event to include selected value on the parent form.
+   * @param event The event.
+   */
+  _handleFormdata(event: Event) {
+    const { formData } = event as any; // TODO: Wait for `FormDataEvent` being available in `lib.dom.d.ts`
+    const { disabled, name, value } = this;
+    if (!disabled) {
+      formData.append(name, value);
+    }
+  }
+
+  /**
    * The color scheme.
    */
   @property({ attribute: 'color-scheme', reflect: true })
@@ -373,6 +386,12 @@ class BXDropdown extends ValidityMixin(HostListenerMixin(FocusMixin(LitElement))
    */
   @property({ attribute: 'label-text' })
   labelText = '';
+
+  /**
+   * Name for the dropdown in the `FormData`
+   */
+  @property()
+  name = '';
 
   /**
    * `true` if this dropdown should be open.


### PR DESCRIPTION
### Related Ticket(s)
None.

### Description
`<bx-dropdown>` currently lacks FormData support that is seen in other component such as `<bx-input>`, meaning that the selected Dropdown value wouldn't get passed upon Form submission. This PR adds support for said feature.

### Changelog

**New**

- added support for `FormData` event in `<bx-dropdown>`
