### PR TITLE
fix(select): show proper attributes in readme

### DIFF
--- a/src/components/select/select-story.mdx
+++ b/src/components/select/select-story.mdx
@@ -12,7 +12,7 @@ The select component allows users to choose one option from a list. It is used i
 
 Note: For `boolean` attributes, `true` means simply setting the attribute (e.g. `<bx-select autofocus>`) and `false` means not setting the attribute (e.g. `<bx-select>` without `autofocus` attribute).
 
-<Props of="bx-select-item" />
+<Props of="bx-select" />
 
 ## `<bx-select-item-group>` attributes, properties and events
 


### PR DESCRIPTION
### Related Ticket(s)
None

### Description
The properties of `<bx-select-item>`'s were rendered twice by accident -- fixed it so `<bx-select>` properties render in the docs.

### Changelog

**New**

- showing `<bx-select>` properties in README
