### PR TITLE
fix(table-search): ensures expanded search opens properly

### DIFF
--- a/src/components/data-table/_table-action.scss
+++ b/src/components/data-table/_table-action.scss
@@ -56,7 +56,7 @@
   @extend .#{$prefix}--toolbar-search-container-expandable;
 
   flex: none;
-  transition: flex $duration--fast-02 motion(entrance, productive);
+  transition: flex 175ms $carbon--standard-easing;
 
   .#{$prefix}--search {
     width: 100%;

--- a/src/components/data-table/_table-action.scss
+++ b/src/components/data-table/_table-action.scss
@@ -1,5 +1,5 @@
 //
-// Copyright IBM Corp. 2019
+// Copyright IBM Corp. 2019, 2021
 //
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
@@ -55,8 +55,11 @@
   @extend .#{$prefix}--toolbar-action;
   @extend .#{$prefix}--toolbar-search-container-expandable;
 
+  flex: none;
+  transition: flex $duration--fast-02 motion(entrance, productive);
+
   .#{$prefix}--search {
-    width: $layout-04;
+    width: 100%;
     height: 100%;
     position: initial;
 
@@ -85,6 +88,8 @@
 
 :host(#{$prefix}-table-toolbar-search[expanded]) {
   @extend .#{$prefix}--toolbar-search-container-active;
+
+  flex: auto;
 }
 
 :host(#{$prefix}-table-toolbar-search[persistent]) {

--- a/src/components/data-table/_table-action.scss
+++ b/src/components/data-table/_table-action.scss
@@ -61,7 +61,6 @@
   .#{$prefix}--search {
     width: 100%;
     height: 100%;
-    position: initial;
 
     .#{$prefix}--search-magnifier {
       height: $layout-04;


### PR DESCRIPTION
### Related Ticket(s)
#656 

### Description
The Carbon updates from a while ago made the Table Search component lose its expanded styles and animations. This PR restores those styles.

### Changelog

**New**

- added styles to ensure search bar opens
