### PR TITLE
fix(search): set focus back to input when search is cleared

### DIFF
--- a/src/components/search/search.ts
+++ b/src/components/search/search.ts
@@ -70,6 +70,10 @@ class BXSearch extends FocusMixin(LitElement) {
         })
       );
       this.value = '';
+
+      // set focus on back to input once search is cleared
+      const input = this.shadowRoot!.querySelector('input');
+      (input as HTMLElement).focus();
     }
   }
 


### PR DESCRIPTION
### Related Ticket(s)

Web component: Dotcom shell - Locale modal- After giving the search input and activation of clear search input button the dialog is getting closed [#6078](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues/6078)

### Description

The Carbon for IBM.com Locale Modal extends the carbon-web-components `search` component. An accessibility issue was reported when search clear button is clicked, the focus doesn't return back to the input. This PR sets the focus back to input when clear input button is clicked.

The Carbon React and Angular instances of `search` have the same behavior where focus returns to input:
https://react.carbondesignsystem.com/?path=/story/components-search--default
https://angular.carbondesignsystem.com/?path=/story/components-search--basic

### Changelog

**Changed**

- set focus back to `input` when `handleClearInputButtonClick()` is triggered
