### PR TITLE
feat(import): introduce simplified entry points

### DIFF
--- a/src/components/accordion/index.ts
+++ b/src/components/accordion/index.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2021
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import './accordion';
+import './accordion-item';

--- a/src/components/breadcrumb/index.ts
+++ b/src/components/breadcrumb/index.ts
@@ -1,0 +1,12 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2021
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import './breadcrumb';
+import './breadcrumb-item';
+import './breadcrumb-link';

--- a/src/components/button/index.ts
+++ b/src/components/button/index.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2021
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import './button';
+import './button-skeleton';

--- a/src/components/checkbox/index.ts
+++ b/src/components/checkbox/index.ts
@@ -1,0 +1,10 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2021
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import './checkbox';

--- a/src/components/code-snippet/index.ts
+++ b/src/components/code-snippet/index.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2021
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import './code-snippet';
+import './code-snippet-skeleton';

--- a/src/components/combo-box/index.ts
+++ b/src/components/combo-box/index.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2021
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import './combo-box';
+import './combo-box-item';

--- a/src/components/content-switcher/index.ts
+++ b/src/components/content-switcher/index.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2021
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import './content-switcher';
+import './content-switcher-item';

--- a/src/components/copy-button/index.ts
+++ b/src/components/copy-button/index.ts
@@ -1,0 +1,10 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2021
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import './copy-button';

--- a/src/components/data-table/index.ts
+++ b/src/components/data-table/index.ts
@@ -1,0 +1,25 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2021
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import './table';
+import './table-batch-actions';
+import './table-body';
+import './table-cell';
+import './table-cell-skeleton';
+import './table-expand-row';
+import './table-expanded-row';
+import './table-head';
+import './table-header-cell';
+import './table-header-cell-skeleton';
+import './table-header-expand-row';
+import './table-header-row';
+import './table-row';
+import './table-toolbar';
+import './table-toolbar-content';
+import './table-toolbar-search';

--- a/src/components/date-picker/index.ts
+++ b/src/components/date-picker/index.ts
@@ -1,0 +1,12 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2021
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import './date-picker';
+import './date-picker-input';
+import './date-picker-input-skeleton';

--- a/src/components/dropdown/index.ts
+++ b/src/components/dropdown/index.ts
@@ -1,0 +1,12 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2021
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import './dropdown';
+import './dropdown-item';
+import './dropdown-skeleton';

--- a/src/components/file-uploader/index.ts
+++ b/src/components/file-uploader/index.ts
@@ -1,0 +1,12 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2021
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import './drop-container';
+import './file-uploader';
+import './file-uploader-item';

--- a/src/components/floating-menu/index.ts
+++ b/src/components/floating-menu/index.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2021
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import './floating-menu';
+import './floating-menu-trigger';

--- a/src/components/form/index.ts
+++ b/src/components/form/index.ts
@@ -1,0 +1,10 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2021
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import './form-item';

--- a/src/components/inline-loading/index.ts
+++ b/src/components/inline-loading/index.ts
@@ -1,0 +1,10 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2021
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import './inline-loading';

--- a/src/components/input/index.ts
+++ b/src/components/input/index.ts
@@ -1,0 +1,10 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2021
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import './input';

--- a/src/components/link/index.ts
+++ b/src/components/link/index.ts
@@ -1,0 +1,10 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2021
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import './link';

--- a/src/components/list/index.ts
+++ b/src/components/list/index.ts
@@ -1,0 +1,12 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2021
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import './list-item';
+import './ordered-list';
+import './unordered-list';

--- a/src/components/loading/index.ts
+++ b/src/components/loading/index.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2021
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import './loading';
+import './loading-icon';

--- a/src/components/modal/index.ts
+++ b/src/components/modal/index.ts
@@ -1,0 +1,17 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2021
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import './modal';
+import './modal-body';
+import './modal-close-button';
+import './modal-footer';
+import './modal-footer-button';
+import './modal-header';
+import './modal-heading';
+import './modal-label';

--- a/src/components/multi-select/index.ts
+++ b/src/components/multi-select/index.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2021
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import './multi-select';
+import './multi-select-item';

--- a/src/components/notification/index.ts
+++ b/src/components/notification/index.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2021
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import './inline-notification';
+import './toast-notification';

--- a/src/components/number-input/index.ts
+++ b/src/components/number-input/index.ts
@@ -1,0 +1,10 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2021
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import './number-input';

--- a/src/components/overflow-menu/index.ts
+++ b/src/components/overflow-menu/index.ts
@@ -1,0 +1,12 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2021
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import './overflow-menu';
+import './overflow-menu-body';
+import './overflow-menu-item';

--- a/src/components/pagination/index.ts
+++ b/src/components/pagination/index.ts
@@ -1,0 +1,12 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2021
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import './page-sizes-select';
+import './pages-select';
+import './pagination';

--- a/src/components/progress-indicator/index.ts
+++ b/src/components/progress-indicator/index.ts
@@ -1,0 +1,12 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2021
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import './progress-indicator';
+import './progress-step';
+import './progress-step-skeleton';

--- a/src/components/radio-button/index.ts
+++ b/src/components/radio-button/index.ts
@@ -1,0 +1,12 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2021
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import './radio-button';
+import './radio-button-group';
+import './radio-button-skeleton';

--- a/src/components/search/index.ts
+++ b/src/components/search/index.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2021
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import './search';
+import './search-skeleton';

--- a/src/components/select/index.ts
+++ b/src/components/select/index.ts
@@ -1,0 +1,12 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2021
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import './select';
+import './select-item';
+import './select-item-group';

--- a/src/components/skeleton-placeholder/index.ts
+++ b/src/components/skeleton-placeholder/index.ts
@@ -1,0 +1,10 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2021
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import './skeleton-placeholder';

--- a/src/components/skeleton-text/index.ts
+++ b/src/components/skeleton-text/index.ts
@@ -1,0 +1,10 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2021
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import './skeleton-text';

--- a/src/components/skip-to-content/index.ts
+++ b/src/components/skip-to-content/index.ts
@@ -1,0 +1,10 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2021
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import './skip-to-content';

--- a/src/components/slider/index.ts
+++ b/src/components/slider/index.ts
@@ -1,0 +1,12 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2021
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import './slider';
+import './slider-input';
+import './slider-skeleton';

--- a/src/components/structured-list/index.ts
+++ b/src/components/structured-list/index.ts
@@ -1,0 +1,17 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2021
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import './structured-list';
+import './structured-list-body';
+import './structured-list-cell';
+import './structured-list-head';
+import './structured-list-header-cell';
+import './structured-list-header-cell-skeleton';
+import './structured-list-header-row';
+import './structured-list-row';

--- a/src/components/tabs/index.ts
+++ b/src/components/tabs/index.ts
@@ -1,0 +1,12 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2021
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import './tab';
+import './tab-skeleton';
+import './tabs-skeleton';

--- a/src/components/tag/index.ts
+++ b/src/components/tag/index.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2021
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import './tag';
+import './filter-tag';

--- a/src/components/textarea/index.ts
+++ b/src/components/textarea/index.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2021
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import './textarea';
+import './textarea-skeleton';

--- a/src/components/tile/index.ts
+++ b/src/components/tile/index.ts
@@ -1,0 +1,15 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2021
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import './clickable-tile';
+import './expandable-tile';
+import './radio-tile';
+import './selectable-tile';
+import './tile';
+import './tile-group';

--- a/src/components/toggle/index.ts
+++ b/src/components/toggle/index.ts
@@ -1,0 +1,10 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2021
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import './toggle';

--- a/src/components/tooltip/index.ts
+++ b/src/components/tooltip/index.ts
@@ -1,0 +1,14 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2021
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import './tooltip';
+import './tooltip-body';
+import './tooltip-definition';
+import './tooltip-footer';
+import './tooltip-icon';

--- a/src/components/ui-shell/index.ts
+++ b/src/components/ui-shell/index.ts
@@ -1,0 +1,22 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2021
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import './side-nav-menu-item';
+import './header';
+import './side-nav';
+import './side-nav-divider';
+import './header-name';
+import './header-nav';
+import './side-nav-link';
+import './header-menu';
+import './header-menu-item';
+import './side-nav-items';
+import './header-menu-button';
+import './header-nav-item';
+import './side-nav-menu';


### PR DESCRIPTION
### Related Ticket(s)

Refs #661 

### Description

This introduces a singular entry point for each component, which would
simplify importing components holistically. In addition, this is a
prerequisite to the generation of CDN artifacts for each components so
that adopters can use the CDN urls instead of including as part of their
 application build process.

### Changelog

**New**

- Singular component level imports
