### PR TITLE
chore(gitignore): ignore `.DS_Store`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 custom-elements.json
 docs/js
 dist
+.DS_Store
 es
 lib
 node_modules


### PR DESCRIPTION
### Description

This PR prevents macOS Finder autogenerated files from being tracked by git since it kept creeping into git diffs from just checking out the repo

### Changelog

**Changed**

- ignore `.DS_Store`