### PR TITLE
chore(release): bump version 1.16.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "carbon-web-components",
-  "version": "1.16.0",
+  "version": "1.16.1",
   "license": "Apache-2.0",
   "main": "es/index.js",
   "module": "es/index.js",


### PR DESCRIPTION
### Related Ticket(s)

No related issue

### Description

This will release `v1.16.1` of `carbon-web-components`.

### Changelog

**Changed**

- `package.json`
