### PR TITLE
fix(header-menu): reenable shadow DOM `delegatesFocus` feature in Safari

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "carbon-web-components",
-  "version": "1.16.1",
+  "version": "1.16.2",
   "license": "Apache-2.0",
   "main": "es/index.js",
   "module": "es/index.js",

--- a/src/components/ui-shell/header-menu.ts
+++ b/src/components/ui-shell/header-menu.ts
@@ -93,7 +93,7 @@ class BXHeaderMenu extends HostListenerMixin(FocusMixin(LitElement)) {
   createRenderRoot() {
     return this.attachShadow({
       mode: 'open',
-      delegatesFocus: Number((/Safari\/(\d+)/.exec(navigator.userAgent) ?? ['', 0])[1]) <= 537,
+      delegatesFocus: true,
     });
   }
 


### PR DESCRIPTION
### Related Ticket(s)

Safari-only mega menu portion of https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues/6956

### Description

This PR restores `delegatesFocus` support for `header-menu` in Safari. This was originally disabled in https://github.com/carbon-design-system/carbon-web-components/pull/496 due to browser crashes, but the [original webkit bug appears to have been resolved](https://bugs.webkit.org/show_bug.cgi?id=215622).

I have scoped this PR to `header-menu` for now but I believe #496 may be reverted after further testing (so far have only tested header-menu, content-switcher-item and checkbox)

#### For the reviewers: 

confirm that the issues fixed by #496 are not present in `BXHeaderMenu`

and confirm that the Cloud masthead is no longer showing the menu item click issue described in https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues/6956 (after modifying `node_modules/carbon-web-components/es/components/ui-shell/header-menu.js` L161 to match the change in this PR)

https://user-images.githubusercontent.com/8265238/130707022-aa6adc5c-f2ef-462d-8d99-abde27afc8d3.mov


### Changelog

**Changed**

- reenable `delegatesFocus` for `BXHeaderMenu` only 
