### PR TITLE
fix(search): trying to fix the focus issue

### DIFF
--- a/src/components/input/input-story.ts
+++ b/src/components/input/input-story.ts
@@ -1,116 +1,26 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019, 2020
+ * Copyright IBM Corp. 2019, 2021
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
 import { html } from 'lit-element';
-import * as knobs from '@storybook/addon-knobs';
-import textNullable from '../../../.storybook/knob-text-nullable';
-import ifNonNull from '../../globals/directives/if-non-null';
-import './input';
-import '../form/form-item';
-import createProps from './stories/helpers';
-import storyDocs from './input-story.mdx';
 
-export const Default = args => {
-  const {
-    autocomplete,
-    autofocus,
-    colorScheme,
-    disabled,
-    helperText,
-    invalid,
-    labelText,
-    name,
-    pattern,
-    placeholder,
-    readonly,
-    required,
-    size,
-    type,
-    validityMessage,
-    value,
-    onInput,
-  } = args?.['bx-input'] ?? {};
-  return html`
-    <bx-input
-      autocomplete="${ifNonNull(autocomplete)}"
-      ?autofocus="${autofocus}"
-      color-scheme="${ifNonNull(colorScheme)}"
-      ?disabled="${disabled}"
-      helper-text="${ifNonNull(helperText)}"
-      ?invalid="${invalid}"
-      label-text="${ifNonNull(labelText)}"
-      name="${ifNonNull(name)}"
-      pattern="${ifNonNull(pattern)}"
-      placeholder="${ifNonNull(placeholder)}"
-      ?readonly="${readonly}"
-      ?required="${required}"
-      size="${ifNonNull(size)}"
-      type="${ifNonNull(type)}"
-      validity-message="${ifNonNull(validityMessage)}"
-      value="${ifNonNull(value)}"
-      @input="${onInput}"
-    ></bx-input>
+export const Default = () =>
+  html`
+    BX-Input:
+
+    <bx-input></bx-input>
+
+    Regular input:
+    <input />
   `;
-};
 
 Default.storyName = 'Default';
 
-export const formItem = args => {
-  const { colorScheme, disabled, value, placeholder, invalid, size, onInput } = args?.['bx-input'] ?? {};
-  return html`
-    <bx-form-item>
-      <bx-input
-        value="${ifNonNull(value)}"
-        color-scheme="${ifNonNull(colorScheme)}"
-        placeholder="${ifNonNull(placeholder)}"
-        size="${ifNonNull(size)}"
-        @input="${onInput}"
-        ?invalid="${invalid}"
-        ?disabled="${disabled}"
-      >
-        <span slot="label-text">Label text</span>
-        <span slot="helper-text">Optional helper text</span>
-        <span slot="validity-message">Something isn't right</span>
-      </bx-input>
-    </bx-form-item>
-  `;
-};
-
-formItem.storyName = 'Form item';
-
-export const withoutFormItemWrapper = args => {
-  const { colorScheme, disabled, value, placeholder, invalid, size, onInput } = args?.['bx-input'] ?? {};
-  return html`
-    <bx-input
-      value="${ifNonNull(value)}"
-      color-scheme="${ifNonNull(colorScheme)}"
-      placeholder="${ifNonNull(placeholder)}"
-      size="${ifNonNull(size)}"
-      @input="${onInput}"
-      ?invalid="${invalid}"
-      ?disabled="${disabled}"
-    >
-      <span slot="label-text">Label text</span>
-      <span slot="helper-text">Optional helper text</span>
-      <span slot="validity-message">Something isn't right</span>
-    </bx-input>
-  `;
-};
-
-withoutFormItemWrapper.storyName = 'Without form item wrapper';
-
 export default {
   title: 'Components/Input',
-  parameters: {
-    ...storyDocs.parameters,
-    knobs: {
-      'bx-input': () => createProps({ ...knobs, textNonEmpty: textNullable }),
-    },
-  },
 };

--- a/src/components/input/input.scss
+++ b/src/components/input/input.scss
@@ -1,16 +1,8 @@
 //
-// Copyright IBM Corp. 2019
+// Copyright IBM Corp. 2019, 2021
 //
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
 //
 
 $css--plex: true !default;
-
-@import 'carbon-components/scss/components/text-input/text-input';
-
-:host(#{$prefix}-input) {
-  // the base text-input class has a 100% so we need to propagate it up to the host element
-  width: 100%;
-  outline: none;
-}

--- a/src/components/input/input.ts
+++ b/src/components/input/input.ts
@@ -8,10 +8,7 @@
  */
 
 import { html, property, query, customElement, LitElement } from 'lit-element';
-import { classMap } from 'lit-html/directives/class-map';
 import settings from 'carbon-components/es/globals/js/settings';
-import WarningFilled16 from '@carbon/icons/lib/warning--filled/16';
-import ifNonEmpty from '../../globals/directives/if-non-empty';
 import FormMixin from '../../globals/mixins/form';
 import ValidityMixin from '../../globals/mixins/validity';
 import { INPUT_COLOR_SCHEME, INPUT_SIZE, INPUT_TYPE } from './defs';
@@ -179,70 +176,9 @@ export default class BXInput extends ValidityMixin(FormMixin(LitElement)) {
     }
   }
 
-  createRenderRoot() {
-    return this.attachShadow({
-      mode: 'open',
-      delegatesFocus: Number((/Safari\/(\d+)/.exec(navigator.userAgent) ?? ['', 0])[1]) <= 537,
-    });
-  }
-
   render() {
-    const { _handleInput: handleInput } = this;
-
-    const invalidIcon = WarningFilled16({ class: `${prefix}--text-input__invalid-icon` });
-
-    const inputClasses = classMap({
-      [`${prefix}--text-input`]: true,
-      [`${prefix}--text-input--${this.colorScheme}`]: this.colorScheme,
-      [`${prefix}--text-input--invalid`]: this.invalid,
-      [`${prefix}--text-input--${this.size}`]: this.size,
-    });
-
-    const labelClasses = classMap({
-      [`${prefix}--label`]: true,
-      [`${prefix}--label--disabled`]: this.disabled,
-    });
-
-    const helperTextClasses = classMap({
-      [`${prefix}--form__helper-text`]: true,
-      [`${prefix}--form__helper-text--disabled`]: this.disabled,
-    });
-
     return html`
-      <label class="${labelClasses}" for="input">
-        <slot name="label-text">
-          ${this.labelText}
-        </slot>
-      </label>
-      <div class="${prefix}--text-input__field-wrapper" ?data-invalid="${this.invalid}">
-        ${this.invalid ? invalidIcon : null}
-        <input
-          ?autocomplete="${this.autocomplete}"
-          ?autofocus="${this.autofocus}"
-          class="${inputClasses}"
-          ?data-invalid="${this.invalid}"
-          ?disabled="${this.disabled}"
-          id="input"
-          name="${ifNonEmpty(this.name)}"
-          pattern="${ifNonEmpty(this.pattern)}"
-          placeholder="${ifNonEmpty(this.placeholder)}"
-          ?readonly="${this.readonly}"
-          ?required="${this.required}"
-          type="${ifNonEmpty(this.type)}"
-          .value="${this._value}"
-          @input="${handleInput}"
-        />
-      </div>
-      <div class="${helperTextClasses}">
-        <slot name="helper-text">
-          ${this.helperText}
-        </slot>
-      </div>
-      <div class="${prefix}--form-requirement">
-        <slot name="validity-message">
-          ${this.validityMessage}
-        </slot>
-      </div>
+      <input />
     `;
   }
 

--- a/src/components/input/input.ts
+++ b/src/components/input/input.ts
@@ -7,10 +7,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { html, property, query, customElement, LitElement } from 'lit-element';
+import { html, customElement, LitElement } from 'lit-element';
 import settings from 'carbon-components/es/globals/js/settings';
-import FormMixin from '../../globals/mixins/form';
-import ValidityMixin from '../../globals/mixins/validity';
 import { INPUT_COLOR_SCHEME, INPUT_SIZE, INPUT_TYPE } from './defs';
 import styles from './input.scss';
 
@@ -26,156 +24,7 @@ const { prefix } = settings;
  * @slot validity-message - The validity message. If present and non-empty, this input shows the UI of its invalid state.
  */
 @customElement(`${prefix}-input`)
-export default class BXInput extends ValidityMixin(FormMixin(LitElement)) {
-  /**
-   * The underlying input element
-   */
-  @query('input')
-  protected _input!: HTMLInputElement;
-
-  /**
-   * The internal value.
-   */
-  protected _value = '';
-
-  /**
-   * Handles `oninput` event on the `<input>`.
-   * @param event The event.
-   */
-  protected _handleInput({ target }: Event) {
-    this.value = (target as HTMLInputElement).value;
-  }
-
-  _handleFormdata(event: Event) {
-    const { formData } = event as any; // TODO: Wait for `FormDataEvent` being available in `lib.dom.d.ts`
-    const { disabled, name, value } = this;
-    if (!disabled) {
-      formData.append(name, value);
-    }
-  }
-
-  /**
-   * May be any of the standard HTML autocomplete options
-   */
-  @property()
-  autocomplete = '';
-
-  /**
-   * Sets the input to be focussed automatically on page load. Defaults to false
-   */
-  @property({ type: Boolean })
-  autofocus = false;
-
-  /**
-   * The color scheme.
-   */
-  @property({ attribute: 'color-scheme', reflect: true })
-  colorScheme = INPUT_COLOR_SCHEME.REGULAR;
-
-  /**
-   * Controls the disabled state of the input
-   */
-  @property({ type: Boolean, reflect: true })
-  disabled = false;
-
-  /**
-   * The helper text.
-   */
-  @property({ attribute: 'helper-text' })
-  helperText = '';
-
-  /**
-   * Controls the invalid state and visibility of the `validityMessage`
-   */
-  @property({ type: Boolean, reflect: true })
-  invalid = false;
-
-  /**
-   * The label text.
-   */
-  @property({ attribute: 'label-text' })
-  labelText = '';
-
-  /**
-   * Name for the input in the `FormData`
-   */
-  @property()
-  name = '';
-
-  /**
-   * Pattern to validate the input against for HTML validity checking
-   */
-  @property()
-  pattern = '';
-
-  /**
-   * Value to display when the input has an empty `value`
-   */
-  @property({ reflect: true })
-  placeholder = '';
-
-  /**
-   * Controls the readonly state of the input
-   */
-  @property({ type: Boolean, reflect: true })
-  readonly = false;
-
-  /**
-   * Boolean property to set the required status
-   */
-  @property({ type: Boolean, reflect: true })
-  required = false;
-
-  /**
-   * The special validity message for `required`.
-   */
-  @property({ attribute: 'required-validity-message' })
-  requiredValidityMessage = 'Please fill out this field.';
-
-  /**
-   * The input box size.
-   */
-  @property({ reflect: true })
-  size = INPUT_SIZE.REGULAR;
-
-  /**
-   * The type of the input. Can be one of the types listed in the INPUT_TYPE enum
-   */
-  @property({ reflect: true })
-  type = INPUT_TYPE.TEXT;
-
-  /**
-   * The validity message. If present and non-empty, this input shows the UI of its invalid state.
-   */
-  @property({ attribute: 'validity-message' })
-  validityMessage = '';
-
-  /**
-   * The value of the input.
-   */
-  @property({ reflect: true })
-  get value() {
-    // FIXME: Figure out how to deal with TS2611
-    // once we have the input we can directly query for the value
-    if (this._input) {
-      return this._input.value;
-    }
-    // but before then _value will work fine
-    return this._value;
-  }
-
-  set value(value) {
-    const oldValue = this._value;
-    this._value = value;
-    // make sure that lit-element updates the right properties
-    this.requestUpdate('value', oldValue);
-    // we set the value directly on the input (when available)
-    // so that programatic manipulation updates the UI correctly
-    if (this._input) {
-      this._input.value = value;
-    }
-  }
-
+export default class BXInput extends LitElement {
   render() {
     return html`
       <input />

--- a/src/components/search/search-story.ts
+++ b/src/components/search/search-story.ts
@@ -1,85 +1,25 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019, 2020
+ * Copyright IBM Corp. 2019, 2021
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
 import { html } from 'lit-element';
-import { action } from '@storybook/addon-actions';
-import { boolean, select } from '@storybook/addon-knobs';
-import textNullable from '../../../.storybook/knob-text-nullable';
-import ifNonNull from '../../globals/directives/if-non-null';
-import { INPUT_SIZE } from '../input/input';
-import { SEARCH_COLOR_SCHEME } from './search';
-import './search-skeleton';
-import storyDocs from './search-story.mdx';
 
-const colorSchemes = {
-  [`Regular`]: null,
-  [`Light (${SEARCH_COLOR_SCHEME.LIGHT})`]: SEARCH_COLOR_SCHEME.LIGHT,
-};
+export const Default = () =>
+  html`
+    BX-Search
 
-const sizes = {
-  'Regular size': null,
-  [`Small size (${INPUT_SIZE.SMALL})`]: INPUT_SIZE.SMALL,
-  [`Extra large size (${INPUT_SIZE.EXTRA_LARGE})`]: INPUT_SIZE.EXTRA_LARGE,
-};
+    <bx-search></bx-search>
 
-export const Default = args => {
-  const { closeButtonAssistiveText, colorScheme, disabled, labelText, name, placeholder, size, type, value, onInput } =
-    args?.['bx-search'] ?? {};
-  return html`
-    <bx-search
-      close-button-assistive-text="${ifNonNull(closeButtonAssistiveText)}"
-      color-scheme="${ifNonNull(colorScheme)}"
-      ?disabled="${disabled}"
-      label-text="${ifNonNull(labelText)}"
-      name="${ifNonNull(name)}"
-      placeholder="${ifNonNull(placeholder)}"
-      size="${ifNonNull(size)}"
-      type="${ifNonNull(type)}"
-      value="${ifNonNull(value)}"
-      @bx-search-input="${onInput}"
-    ></bx-search>
+    Regular input
+    <input />
   `;
-};
 
 Default.storyName = 'Default';
-
-Default.parameters = {
-  ...storyDocs.parameters,
-  knobs: {
-    'bx-search': () => ({
-      closeButtonAssistiveText: textNullable(
-        'The label text for the close button (close-button-assistive-text)',
-        'Clear search input'
-      ),
-      colorScheme: select('Color scheme (color-scheme)', colorSchemes, null),
-      disabled: boolean('Disabled (disabled)', false),
-      labelText: textNullable('Label text (label-text)', 'Search'),
-      name: textNullable('Name (name)', ''),
-      placeholder: textNullable('Placeholder text (placeholder)', ''),
-      size: select('Searh size (size)', sizes, null),
-      type: textNullable('The type of the <input> (type)', ''),
-      value: textNullable('Value (value)', ''),
-      onInput: action('bx-search-input'),
-    }),
-  },
-};
-
-export const skeleton = () =>
-  html`
-    <bx-search-skeleton></bx-search-skeleton>
-  `;
-
-skeleton.parameters = {
-  percy: {
-    skip: true,
-  },
-};
 
 export default {
   title: 'Components/Search',

--- a/src/components/search/search.scss
+++ b/src/components/search/search.scss
@@ -1,55 +1,8 @@
 //
-// Copyright IBM Corp. 2019, 2020
+// Copyright IBM Corp. 2019, 2021
 //
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
 //
 
 $css--plex: true !default;
-
-@import 'carbon-components/scss/globals/scss/helper-mixins';
-@import 'carbon-components/scss/components/form/form';
-@import 'carbon-components/scss/components/search/search';
-
-:host(#{$prefix}-search),
-:host(#{$prefix}-search-skeleton) {
-  @extend .#{$prefix}--search--lg;
-}
-
-:host(#{$prefix}-search) {
-  @extend .#{$prefix}--search;
-
-  outline: none;
-}
-
-:host(#{$prefix}-search[size='sm']),
-:host(#{$prefix}-search-skeleton[size='sm']) {
-  @extend .#{$prefix}--search--sm;
-}
-
-:host(#{$prefix}-search[size='lg']),
-:host(#{$prefix}-search-skeleton[size='lg']) {
-  @extend .#{$prefix}--search--lg;
-}
-
-:host(#{$prefix}-search[size='xl']),
-:host(#{$prefix}-search-skeleton[size='xl']) {
-  @extend .#{$prefix}--search--xl;
-}
-
-:host(#{$prefix}-search[color-scheme='light']) {
-  @extend .#{$prefix}--search--light;
-}
-
-:host(#{$prefix}-search-skeleton) {
-  width: 100%;
-
-  .#{$prefix}--search-input {
-    @include skeleton;
-    width: 100%;
-
-    &::placeholder {
-      color: transparent;
-    }
-  }
-}

--- a/src/components/search/search.ts
+++ b/src/components/search/search.ts
@@ -7,93 +7,88 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { classMap } from 'lit-html/directives/class-map';
-import { html, property, customElement, LitElement } from 'lit-element';
-import Close16 from '@carbon/icons/lib/close/16';
-import Close20 from '@carbon/icons/lib/close/20';
-import Search16 from '@carbon/icons/lib/search/16';
+import { html, property, query, customElement, LitElement } from 'lit-element';
 import settings from 'carbon-components/es/globals/js/settings';
-import ifNonEmpty from '../../globals/directives/if-non-empty';
-import FocusMixin from '../../globals/mixins/focus';
-import { INPUT_SIZE } from '../input/input';
-import { SEARCH_COLOR_SCHEME } from './defs';
+import FormMixin from '../../globals/mixins/form';
+import ValidityMixin from '../../globals/mixins/validity';
+import { INPUT_COLOR_SCHEME, INPUT_SIZE, INPUT_TYPE } from '../input/defs';
 import styles from './search.scss';
 
-export { SEARCH_COLOR_SCHEME };
+export { INPUT_COLOR_SCHEME, INPUT_SIZE, INPUT_TYPE };
 
 const { prefix } = settings;
 
 /**
- * Search box.
- * @element bx-search
- * @csspart search-icon The search icon.
- * @csspart label-text The label text.
- * @csspart input The input box.
- * @csspart close-button The close button.
- * @csspart close-icon The close icon.
- * @fires bx-search-input - The custom event fired after the search content is changed upon a user gesture.
+ * Input element. Supports all the usual attributes for textual input types
+ * @element bx-input
+ * @slot helper-text - The helper text.
+ * @slot label-text - The label text.
+ * @slot validity-message - The validity message. If present and non-empty, this input shows the UI of its invalid state.
  */
 @customElement(`${prefix}-search`)
-class BXSearch extends FocusMixin(LitElement) {
+export default class BXSearch extends ValidityMixin(FormMixin(LitElement)) {
   /**
-   * Handles `input` event on the `<input>` in the shadow DOM.
+   * The underlying input element
    */
-  private _handleInput(event: Event) {
-    const { target } = event;
-    const { value } = target as HTMLInputElement;
-    this.dispatchEvent(
-      new CustomEvent((this.constructor as typeof BXSearch).eventInput, {
-        bubbles: true,
-        composed: true,
-        cancelable: false,
-        detail: {
-          value,
-        },
-      })
-    );
-    this.value = value;
+  @query('input')
+  protected _input!: HTMLInputElement;
+
+  /**
+   * The internal value.
+   */
+  protected _value = '';
+
+  /**
+   * Handles `oninput` event on the `<input>`.
+   * @param event The event.
+   */
+  protected _handleInput({ target }: Event) {
+    this.value = (target as HTMLInputElement).value;
   }
 
-  /**
-   * Handles `click` event on the button to clear search box content.
-   */
-  private _handleClearInputButtonClick() {
-    if (this.value) {
-      this.dispatchEvent(
-        new CustomEvent((this.constructor as typeof BXSearch).eventInput, {
-          bubbles: true,
-          composed: true,
-          cancelable: false,
-          detail: {
-            value: '',
-          },
-        })
-      );
-      this.value = '';
-
-      // set focus on back to input once search is cleared
-      const input = this.shadowRoot!.querySelector('input');
-      (input as HTMLElement).focus();
+  _handleFormdata(event: Event) {
+    const { formData } = event as any; // TODO: Wait for `FormDataEvent` being available in `lib.dom.d.ts`
+    const { disabled, name, value } = this;
+    if (!disabled) {
+      formData.append(name, value);
     }
   }
 
   /**
-   * The assistive text for the close button.
+   * May be any of the standard HTML autocomplete options
    */
-  @property({ attribute: 'close-button-assistive-text' })
-  closeButtonAssistiveText = '';
+  @property()
+  autocomplete = '';
+
+  /**
+   * Sets the input to be focussed automatically on page load. Defaults to false
+   */
+  @property({ type: Boolean })
+  autofocus = false;
 
   /**
    * The color scheme.
    */
   @property({ attribute: 'color-scheme', reflect: true })
-  colorScheme = SEARCH_COLOR_SCHEME.REGULAR;
+  colorScheme = INPUT_COLOR_SCHEME.REGULAR;
 
   /**
-   * `true` if the search box should be disabled.
+   * Controls the disabled state of the input
    */
   @property({ type: Boolean, reflect: true })
   disabled = false;
+
+  /**
+   * The helper text.
+   */
+  @property({ attribute: 'helper-text' })
+  helperText = '';
+
+  /**
+   * Controls the invalid state and visibility of the `validityMessage`
+   */
+  @property({ type: Boolean, reflect: true })
+  invalid = false;
 
   /**
    * The label text.
@@ -102,104 +97,90 @@ class BXSearch extends FocusMixin(LitElement) {
   labelText = '';
 
   /**
-   * The form name.
+   * Name for the input in the `FormData`
    */
   @property()
   name = '';
 
   /**
-   * The placeholder text.
+   * Pattern to validate the input against for HTML validity checking
    */
   @property()
+  pattern = '';
+
+  /**
+   * Value to display when the input has an empty `value`
+   */
+  @property({ reflect: true })
   placeholder = '';
 
   /**
-   * The search box size.
+   * Controls the readonly state of the input
+   */
+  @property({ type: Boolean, reflect: true })
+  readonly = false;
+
+  /**
+   * Boolean property to set the required status
+   */
+  @property({ type: Boolean, reflect: true })
+  required = false;
+
+  /**
+   * The special validity message for `required`.
+   */
+  @property({ attribute: 'required-validity-message' })
+  requiredValidityMessage = 'Please fill out this field.';
+
+  /**
+   * The input box size.
    */
   @property({ reflect: true })
   size = INPUT_SIZE.REGULAR;
 
   /**
-   * The `<input>` name.
+   * The type of the input. Can be one of the types listed in the INPUT_TYPE enum
    */
-  @property()
-  type = '';
+  @property({ reflect: true })
+  type = INPUT_TYPE.TEXT;
 
   /**
-   * The value.
+   * The validity message. If present and non-empty, this input shows the UI of its invalid state.
    */
-  @property({ type: String })
-  value = '';
+  @property({ attribute: 'validity-message' })
+  validityMessage = '';
 
-  createRenderRoot() {
-    return this.attachShadow({
-      mode: 'open',
-      delegatesFocus: Number((/Safari\/(\d+)/.exec(navigator.userAgent) ?? ['', 0])[1]) <= 537,
-    });
+  /**
+   * The value of the input.
+   */
+  @property({ reflect: true })
+  get value() {
+    // FIXME: Figure out how to deal with TS2611
+    // once we have the input we can directly query for the value
+    if (this._input) {
+      return this._input.value;
+    }
+    // but before then _value will work fine
+    return this._value;
+  }
+
+  set value(value) {
+    const oldValue = this._value;
+    this._value = value;
+    // make sure that lit-element updates the right properties
+    this.requestUpdate('value', oldValue);
+    // we set the value directly on the input (when available)
+    // so that programatic manipulation updates the UI correctly
+    if (this._input) {
+      this._input.value = value;
+    }
   }
 
   render() {
-    const {
-      closeButtonAssistiveText,
-      disabled,
-      labelText,
-      name,
-      placeholder,
-      size,
-      type,
-      value = '',
-      _handleInput: handleInput,
-      _handleClearInputButtonClick: handleClearInputButtonClick,
-    } = this;
-    const clearClasses = classMap({
-      [`${prefix}--search-close`]: true,
-      [`${prefix}--search-close--hidden`]: !this.value,
-    });
     return html`
-      ${Search16({
-        part: 'search-icon',
-        class: `${prefix}--search-magnifier-icon`,
-        role: 'img',
-      })}
-      <label for="input" part="label-text" class="${prefix}--label">
-        <slot>${labelText}</slot>
-      </label>
-      <input
-        id="input"
-        part="input"
-        type="${ifNonEmpty(type)}"
-        class="${prefix}--search-input"
-        ?disabled="${disabled}"
-        name="${ifNonEmpty(name)}"
-        placeholder="${ifNonEmpty(placeholder)}"
-        role="searchbox"
-        .value="${value}"
-        @input="${handleInput}"
-      />
-      <button
-        part="close-button"
-        class="${clearClasses}"
-        @click="${handleClearInputButtonClick}"
-        type="button"
-        aria-label="${closeButtonAssistiveText}"
-      >
-        ${(size === INPUT_SIZE.SMALL ? Close16 : Close20)({
-          part: 'close-icon',
-          'aria-label': closeButtonAssistiveText,
-          role: 'img',
-        })}
-      </button>
+      <input />
     `;
-  }
-
-  /**
-   * The name of the custom event fired after the search content is changed upon a user gesture.
-   */
-  static get eventInput() {
-    return `${prefix}-search-input`;
   }
 
   static styles = styles; // `styles` here is a `CSSResult` generated by custom WebPack loader
 }
-
-export default BXSearch;

--- a/src/components/search/search.ts
+++ b/src/components/search/search.ts
@@ -7,10 +7,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { html, property, query, customElement, LitElement } from 'lit-element';
+import { html, customElement, LitElement } from 'lit-element';
 import settings from 'carbon-components/es/globals/js/settings';
-import FormMixin from '../../globals/mixins/form';
-import ValidityMixin from '../../globals/mixins/validity';
 import { INPUT_COLOR_SCHEME, INPUT_SIZE, INPUT_TYPE } from '../input/defs';
 import styles from './search.scss';
 
@@ -26,156 +24,7 @@ const { prefix } = settings;
  * @slot validity-message - The validity message. If present and non-empty, this input shows the UI of its invalid state.
  */
 @customElement(`${prefix}-search`)
-export default class BXSearch extends ValidityMixin(FormMixin(LitElement)) {
-  /**
-   * The underlying input element
-   */
-  @query('input')
-  protected _input!: HTMLInputElement;
-
-  /**
-   * The internal value.
-   */
-  protected _value = '';
-
-  /**
-   * Handles `oninput` event on the `<input>`.
-   * @param event The event.
-   */
-  protected _handleInput({ target }: Event) {
-    this.value = (target as HTMLInputElement).value;
-  }
-
-  _handleFormdata(event: Event) {
-    const { formData } = event as any; // TODO: Wait for `FormDataEvent` being available in `lib.dom.d.ts`
-    const { disabled, name, value } = this;
-    if (!disabled) {
-      formData.append(name, value);
-    }
-  }
-
-  /**
-   * May be any of the standard HTML autocomplete options
-   */
-  @property()
-  autocomplete = '';
-
-  /**
-   * Sets the input to be focussed automatically on page load. Defaults to false
-   */
-  @property({ type: Boolean })
-  autofocus = false;
-
-  /**
-   * The color scheme.
-   */
-  @property({ attribute: 'color-scheme', reflect: true })
-  colorScheme = INPUT_COLOR_SCHEME.REGULAR;
-
-  /**
-   * Controls the disabled state of the input
-   */
-  @property({ type: Boolean, reflect: true })
-  disabled = false;
-
-  /**
-   * The helper text.
-   */
-  @property({ attribute: 'helper-text' })
-  helperText = '';
-
-  /**
-   * Controls the invalid state and visibility of the `validityMessage`
-   */
-  @property({ type: Boolean, reflect: true })
-  invalid = false;
-
-  /**
-   * The label text.
-   */
-  @property({ attribute: 'label-text' })
-  labelText = '';
-
-  /**
-   * Name for the input in the `FormData`
-   */
-  @property()
-  name = '';
-
-  /**
-   * Pattern to validate the input against for HTML validity checking
-   */
-  @property()
-  pattern = '';
-
-  /**
-   * Value to display when the input has an empty `value`
-   */
-  @property({ reflect: true })
-  placeholder = '';
-
-  /**
-   * Controls the readonly state of the input
-   */
-  @property({ type: Boolean, reflect: true })
-  readonly = false;
-
-  /**
-   * Boolean property to set the required status
-   */
-  @property({ type: Boolean, reflect: true })
-  required = false;
-
-  /**
-   * The special validity message for `required`.
-   */
-  @property({ attribute: 'required-validity-message' })
-  requiredValidityMessage = 'Please fill out this field.';
-
-  /**
-   * The input box size.
-   */
-  @property({ reflect: true })
-  size = INPUT_SIZE.REGULAR;
-
-  /**
-   * The type of the input. Can be one of the types listed in the INPUT_TYPE enum
-   */
-  @property({ reflect: true })
-  type = INPUT_TYPE.TEXT;
-
-  /**
-   * The validity message. If present and non-empty, this input shows the UI of its invalid state.
-   */
-  @property({ attribute: 'validity-message' })
-  validityMessage = '';
-
-  /**
-   * The value of the input.
-   */
-  @property({ reflect: true })
-  get value() {
-    // FIXME: Figure out how to deal with TS2611
-    // once we have the input we can directly query for the value
-    if (this._input) {
-      return this._input.value;
-    }
-    // but before then _value will work fine
-    return this._value;
-  }
-
-  set value(value) {
-    const oldValue = this._value;
-    this._value = value;
-    // make sure that lit-element updates the right properties
-    this.requestUpdate('value', oldValue);
-    // we set the value directly on the input (when available)
-    // so that programatic manipulation updates the UI correctly
-    if (this._input) {
-      this._input.value = value;
-    }
-  }
-
+export default class BXSearch extends LitElement {
   render() {
     return html`
       <input />


### PR DESCRIPTION
### Related Ticket(s)
N/A

### Description
This PR aims to show the strange behavior in which some story components are able to ignore the Storybook shortcuts while typing on an input bar, while others do not.

I noticed `BXSearch` has this bug, in which upon typing `1` the search bar will go out of focus, while `BXInput` allows for the typing of `1`'s, `a`'s and other Storybook shortcut keys without interrupting the typing experience.

I've stripped both the `BXSearch` and `BXInput` components down to their raw `input` element in the shadow DOM, and even then, `BXSearch` still is unable to keep the input element focused when using one of the Storybook shortcut keys while `BXInput` can. 

https://user-images.githubusercontent.com/24970122/139151517-94759b2d-6962-432e-88ef-cafb115ceb56.mov

Because of the amount of changes I made to the files, it probably won't pass the ci-checks so the preview might not render, so pulling this branch into your local machine might be the only way to test this

