### PR TITLE
fix(deploy): properly deploy when a new tag is created

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,7 +1,7 @@
 name: deploy
 
 on:
-  push:
+  create:
     tags:
       - 'v*'
 


### PR DESCRIPTION
### Related Ticket(s)

No related issue

### Description

This will properly deploy the storybook instance when there is a new tag created rather than by push.

### Changelog

**Changed**

- `deploy.yml`
