### PR TITLE
fix(github-actions): switched percy update to use ubuntu latest

### DIFF
--- a/.github/workflows/percy-update-base.yml
+++ b/.github/workflows/percy-update-base.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   percy:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         node-version: ['12.x']


### PR DESCRIPTION
### Related Ticket(s)

No related issue

### Description

Noticed that this job was no longer running. I believe that Ubuntu 16 was deprecated by Github, so need to update to use the latest Ubuntu instead.

### Changelog

**Changed**

- `percy-update-base.yml`
