### PR TITLE
chore(lit): moved lit-element/lit-html to core dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,4 +14,6 @@ tests/coverage
 .vscode
 .idea
 .env
+.npmrc
+yarn-error.log
 CHANGELOG.md

--- a/README.md
+++ b/README.md
@@ -172,15 +172,31 @@ To install `carbon-web-components` in your project, you will need to run the
 following command using [npm](https://www.npmjs.com/):
 
 ```bash
-npm install --save carbon-web-components carbon-components lit-html lit-element
+npm install --save carbon-web-components
 ```
 
 If you prefer [Yarn](https://yarnpkg.com/en/), use the following command
 instead:
 
 ```bash
-yarn add carbon-web-components carbon-components lit-html lit-element
+yarn add carbon-web-components
 ```
+
+> NOTE: Carbon and Lit dependencies will be managed by Carbon Web Components starting in
+> `v1.19.0`. For earlier versions, these dependencies will have to be installed
+> separately:
+>
+> npm:
+>
+> ```bash
+> npm install --save carbon-components lit-html lit-element
+> ```
+>
+> Yarn:
+>
+> ```bash
+> yarn add carbon-components lit-html lit-element
+> ```
 
 #### Basic usage
 

--- a/package.json
+++ b/package.json
@@ -51,19 +51,23 @@
     "build:ngc": "yarn build:ngc:esm2015 && yarn build:ngc:esm5",
     "build:ngc:esm2015": "ngc -p tsconfig-angular-esm2015.json",
     "build:ngc:esm5": "ngc -p tsconfig-angular-esm5.json",
+    "build-storybook:angular": "node --max-old-space-size=8192 node_modules/@storybook/angular/bin/build.js -c .storybook/angular -o storybook-static-angular",
+    "build-storybook:react": "gulp build:modules:react && node --max-old-space-size=8192 node_modules/@storybook/react/bin/build.js -c .storybook/react -o storybook-static-react",
+    "build-storybook:vue": "node --max-old-space-size=8192 node_modules/@storybook/vue/bin/build.js -c .storybook/vue -o storybook-static-vue",
     "ci-check": "yarn wca && yarn format:diff && yarn lint:src && yarn typecheck && yarn build && yarn test:unit && yarn lint:dist",
     "clean": "gulp clean",
     "format": "prettier --write \"**/*.{css,js,md,scss}\"",
     "format:diff": "prettier --check \"**/*.{css,js,md,scss}\"",
     "format:staged": "prettier --write",
     "lint": "yarn lint:src && yarn lint:dist",
-    "lint:src": "yarn lint:license:src && yarn lint:scripts",
     "lint:dist": "yarn lint:license:dist",
     "lint:license:src": "gulp lint:license:src",
     "lint:license:dist": "gulp lint:license:dist",
-    "lint:scripts": "eslint --ext .js,.ts,.tsx .",
     "lint:license:staged": "tools/check-license.js -w",
+    "lint:scripts": "eslint --ext .js,.ts,.tsx .",
     "lint:scripts:staged": "eslint",
+    "lint:src": "yarn lint:license:src && yarn lint:scripts",
+    "reset": "yarn cache clean && yarn clean && yarn install && yarn build",
     "test": "gulp test && yarn test:integration",
     "test:integration": "yarn test:integration:build && yarn test:integration:ui",
     "test:integration:build": "jest -c tests/integration/build/jest.config.js --runInBand",
@@ -75,18 +79,17 @@
     "storybook:angular": "node node_modules/@storybook/angular/bin/index.js -p 9001 -c .storybook/angular",
     "storybook:react": "node node_modules/@storybook/react/bin/index.js -p 9002 -c .storybook/react",
     "storybook:vue": "node node_modules/@storybook/vue/bin/index.js -p 9003 -c .storybook/vue",
-    "build-storybook:angular": "node --max-old-space-size=8192 node_modules/@storybook/angular/bin/build.js -c .storybook/angular -o storybook-static-angular",
-    "build-storybook:react": "gulp build:modules:react && node --max-old-space-size=8192 node_modules/@storybook/react/bin/build.js -c .storybook/react -o storybook-static-react",
-    "build-storybook:vue": "node --max-old-space-size=8192 node_modules/@storybook/vue/bin/build.js -c .storybook/vue -o storybook-static-vue",
     "wca": "web-component-analyzer analyze src --outFile custom-elements.json"
   },
   "resolutions": {
     "babel-plugin-transform-vue-jsx": "^4.0.0",
-    "lit-html": "^1.3.0",
     "prettier": "^1.19.0"
   },
   "dependencies": {
     "@babel/runtime": "^7.8.0",
+    "carbon-components": "10.47.0",
+    "lit-element": "2.3.1",
+    "lit-html": "1.3.0",
     "lodash-es": "^4.17.0"
   },
   "devDependencies": {
@@ -157,7 +160,6 @@
     "babel-preset-vue": "^2.0.0",
     "bluebird": "^3.5.0",
     "cache-loader": "^4.1.0",
-    "carbon-components": "^10.47.0",
     "child-process-promise": "^2.2.0",
     "commander": "^2.13.0",
     "core-js": "^3.0.0",
@@ -222,8 +224,6 @@
     "karma-spec-reporter": "0.0.32",
     "karma-webpack": "^4.0.0",
     "lint-staged": "^10.2.0",
-    "lit-element": "^2.3.0",
-    "lit-html": "^1.2.0",
     "magic-string": "^0.25.0",
     "mini-css-extract-plugin": "^0.5.0",
     "mkdirp": "^0.5.0",
@@ -275,10 +275,7 @@
     "zone.js": "^0.8.0"
   },
   "peerDependencies": {
-    "carbon-components": "~10.47.0",
-    "flatpickr": "4.6.1",
-    "lit-element": "^2.3.0",
-    "lit-html": "^1.2.0"
+    "flatpickr": "4.6.1"
   },
   "commitlint": {
     "extends": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -8372,7 +8372,7 @@ capture-exit@^2.0.0:
   dependencies:
     rsvp "^4.8.4"
 
-carbon-components@^10.47.0:
+carbon-components@10.47.0:
   version "10.47.0"
   resolved "https://registry.yarnpkg.com/carbon-components/-/carbon-components-10.47.0.tgz#fbc984531e3abe9d072dc88b371bd5bb397c2b0d"
   integrity sha512-ThjNOMUL6kFgMORvLII76WMGD4VEqgSA+wft5AK9imhsAIFP/54LxzAH+FSpZxP+VA0FjbunUUIv3pKOodedbA==
@@ -15517,14 +15517,14 @@ listr2@^2.1.0:
     rxjs "^6.6.0"
     through "^2.3.8"
 
-lit-element@^2.3.0:
+lit-element@2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/lit-element/-/lit-element-2.3.1.tgz#73343b978fa1e73d60526c6bb6ad60f53a16c343"
   integrity sha512-tOcUAmeO3BzwiQ7FGWdsshNvC0HVHcTFYw/TLIImmKwXYoV0E7zCBASa8IJ7DiP4cen/Yoj454gS0qqTnIGsFA==
   dependencies:
     lit-html "^1.1.1"
 
-lit-html@^1.1.1, lit-html@^1.2.0, lit-html@^1.3.0:
+lit-html@1.3.0, lit-html@^1.1.1:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/lit-html/-/lit-html-1.3.0.tgz#c80f3cc5793a6dea6c07172be90a70ab20e56034"
   integrity sha512-0Q1bwmaFH9O14vycPHw8C/IeHMk/uSDldVLIefu/kfbTBGIc44KGH6A8p1bDfxUfHdc8q6Ct7kQklWoHgr4t1Q==
@@ -22399,9 +22399,9 @@ typescript@^3.5.3:
   integrity sha512-/P5lkRXkWHNAbcJIiHPfRoKqyd7bsyCma1hZNUGfn20qm64T6ZBlrzprymeu918H+mB/0rIg2gGK/BXkhhYgBw==
 
 typescript@^3.8.0:
-  version "3.8.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
-  integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==
+  version "3.9.10"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.10.tgz#70f3910ac7a51ed6bef79da7800690b19bf778b8"
+  integrity sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==
 
 ua-parser-js@^0.7.23:
   version "0.7.24"


### PR DESCRIPTION
### Related Ticket(s)

Refs https://github.com/carbon-design-system/carbon-web-components/issues/723

### Description

This moved the `lit-element`/`lit-html` libraries to core `dependencies`. `peerDependencies` was also cleaned up to no longer include `carbon-components`, as that has already been managed in `dependencies` for awhile now.

The scripts were also alphabetized in `package.json`, and added some additional entries to `.gitignore`.

### Changelog

**Changed**

- `lit-element`/`lit-html` moved to `dependencies`
- trimmed down `peerDependencies`
- Added `.npmrc` and `yarn-error.log` to `.gitignore`
- alphabetized scripts in `package.json`
- `README.md` updated to reflect installation changes
