### PR TITLE
chore: setup actions/setup-node@v2 cache

### DIFF
--- a/.github/workflows/ci-check.yml
+++ b/.github/workflows/ci-check.yml
@@ -14,6 +14,7 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
+          cache: 'yarn'
       - name: Install dependencies
         run: yarn install --frozen-lockfile --offline
       - run: sudo apt-get install xvfb
@@ -37,6 +38,7 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
+          cache: 'yarn'
       - name: Install dependencies
         run: yarn install --frozen-lockfile --offline
       - name: Install xvfb

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,6 +14,7 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: '12.x'
+          cache: 'yarn'
       - name: Install dependencies
         run: yarn install
       - name: Build project

--- a/.github/workflows/percy-update-base.yml
+++ b/.github/workflows/percy-update-base.yml
@@ -18,6 +18,7 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
+          cache: 'yarn'
       - name: Install dependencies
         run: yarn install
       - name: Install xvfb

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,6 +16,7 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: '12.x'
+          cache: 'yarn'
       - name: Install dependencies
         run: yarn install --frozen-lockfile --offline
       - name: Build project

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -10,6 +10,7 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: '12.x'
+          cache: 'yarn'
       - name: Install dependencies
         run: yarn install --frozen-lockfile --offline
       - name: eslint


### PR DESCRIPTION
As mention #729, just enabled the actions/setup-node@v2 built-in cache.

Let's see how improves the CI time.