### PR TITLE
fix(github-actions): turn back on percy update base

### DIFF
--- a/.github/workflows/dependabot-yarn-mirror.yml
+++ b/.github/workflows/dependabot-yarn-mirror.yml
@@ -15,15 +15,24 @@ jobs:
         node-version: ['14.x']
     steps:
       - uses: actions/checkout@v2
+        with:
+          token: ${{secrets.GH_TOKEN}}
       - uses: fregante/setup-git-user@v1
       - name: Use Node.js
         uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
           cache: yarn
+      - name: Get branch name
+        shell: bash
+        run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
+        id: get_branch
       - name: Update yarn offline mirror
         if: contains(github.event.pull_request.labels.*.name, 'dependencies')
         run: |
           yarn
           git add -A
-          if [[ ! -z $(git status -s) ]] ; then git commit -m "chore(yarn): update yarn offline mirror" && git push; fi
+          if [[ ! -z $(git status -s) ]] ; then
+            git commit -m "chore(yarn): update yarn offline mirror"
+            git push origin ${{ steps.get_branch.outputs.branch }}
+          fi

--- a/.github/workflows/percy-update-base.yml
+++ b/.github/workflows/percy-update-base.yml
@@ -12,8 +12,6 @@ concurrency:
 
 jobs:
   percy:
-    # Prevents action from creating a PR on forks
-    if: github.repository == github.event.pull_request.head.repo.full_name
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
### Related Ticket(s)

No related issue

### Description

Noticed that the percy base wasn't getting updated, and saw that the rule added was causing this. This should re-enable percy base updating.

### Changelog

**Changed**

- `percy-update-base.yml` remove repo target check rule
