### PR TITLE
Revert "chore: make the forks check dynamic (#753)"

### DIFF
--- a/.github/workflows/percy-update-base.yml
+++ b/.github/workflows/percy-update-base.yml
@@ -12,6 +12,8 @@ concurrency:
 
 jobs:
   percy:
+    # Prevents action from creating a PR on forks
+    if: github.repository == 'carbon-design-system/carbon-web-components'
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   publish:
     # Prevents action from creating a PR on forks
-    if: github.repository == github.event.pull_request.head.repo.full_name
+    if: github.repository == 'carbon-design-system/carbon-web-components'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Sorry team, after some investigations we discovered that for on push actions there is no `pull_request` reference and the checks fail. This PR reverts the changes from my previous PR.