### PR TITLE
chore(renovate): revert back to default renovate behavior

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,8 +1,6 @@
 {
   "extends": [
     "config:base",
-    ":separateMultipleMajorReleases",
-    ":separatePatchReleases",
     ":maintainLockFilesWeekly"
   ],
   "rangeStrategy": "bump"


### PR DESCRIPTION
### Related Ticket(s)

No related issue

### Description

After observing other repo behavior, removing the separation of versions into separate PRs is probably better as it would start to generate too many PRs and would be a bit spammy. This will revert the config to closer to the default behavior.

### Changelog

**Changed**

- Removed `: separateMultipleMajorReleases`, and `:separatePatchReleases` default configs
