### PR TITLE
chore(release): bump to v1.20.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "carbon-web-components",
-  "version": "1.19.0",
+  "version": "1.20.0",
   "license": "Apache-2.0",
   "repository": "https://github.com/carbon-design-system/carbon-web-components",
   "bugs": "https://github.com/carbon-design-system/carbon-web-components/issues",


### PR DESCRIPTION
### Related Ticket(s)

No related issue

### Description

This bumps the library to v1.20.0.

### Changelog

**Changed**

- `package.json` bumped to version `1.20.0`
