### PR TITLE
docs(file-uploader): correct file uploader events documentation

### DIFF
--- a/src/components/file-uploader/file-uploader-item.ts
+++ b/src/components/file-uploader/file-uploader-item.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2021
+ * Copyright IBM Corp. 2020, 2022
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -25,10 +25,10 @@ const { prefix } = settings;
  * @element bx-file-uploader-item
  * @slot validity-message The validity message.
  * @slot validity-message-supplement The supplemental validity message.
- * @fires bx-file uploader-item-beingdeleted
- *   The custom event fired before this file uplodaer item is being deleted upon a user gesture.
+ * @fires bx-file-uploader-item-beingdeleted
+ *   The custom event fired before this file uploader item is being deleted upon a user gesture.
  *   Cancellation of this event stops the user-initiated action of deleting this file uploader item.
- * @fires bx-file uploader-item-deleted - The custom event fired after this file uplodaer item is deleted upon a user gesture.
+ * @fires bx-file-uploader-item-deleted - The custom event fired after this file uploader item is deleted upon a user gesture.
  */
 @customElement(`${prefix}-file-uploader-item`)
 class BXFileUploaderItem extends LitElement {


### PR DESCRIPTION
### Related Ticket(s)

[Storybook]: Webcomponents File Upload Wrong Events Documentation #918

### Description

Storybook for `file-uploader` was not showing correct file uploader events. This PR corrects it.

BEFORE:
<img width="778" alt="Screen Shot 2022-01-04 at 4 43 41 PM" src="https://user-images.githubusercontent.com/54281166/148127988-e0a5d5eb-494c-46c0-9c6b-d8b06a9fb4ea.png">

AFTER:
<img width="874" alt="Screen Shot 2022-01-04 at 4 43 19 PM" src="https://user-images.githubusercontent.com/54281166/148127967-b5c4e60c-d385-4b76-b1fc-a527a2d394f1.png">


### Changelog

**Changed**

- fix documentation

