### PR TITLE
chore(release): bump to v1.21.0

### DIFF
--- a/.github/workflows/dependabot-yarn-mirror.yml
+++ b/.github/workflows/dependabot-yarn-mirror.yml
@@ -1,0 +1,46 @@
+name: dependabot-yarn-mirror
+
+on:
+  push:
+    branches: [ dependabot/**/* ]
+  pull_request:
+    branches: [ dependabot/**/* ]
+
+concurrency:
+  group: dependabot-yarn-mirror-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  yarn-mirror:
+    if: github.repository == 'carbon-design-system/carbon-web-components'
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: ['14.x']
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.GH_TOKEN }}
+      - name: Use Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'yarn'
+      - name: Get branch name
+        shell: bash
+        run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
+        id: get_branch
+      - name: Install dependencies
+        run: yarn install
+      - name: Push changes
+        run: |
+          if [ -z "$(git status --porcelain)" ]; then
+            echo "Mirror is clean, exiting..."
+          else
+            git config --global user.email ${{ secrets.BOT_EMAIL }}
+            git config --global user.name ${{ secrets.BOT_NAME }}
+
+            git add -A
+            git commit -m "chore(yarn): update yarn offline mirror"
+            git push origin ${{ steps.get_branch.outputs.branch }}
+          fi

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,6 +14,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
       - name: Use Node.js 16.x
         uses: actions/setup-node@v2
         with:
@@ -46,5 +47,4 @@ jobs:
         with:
           bodyFile: "CHANGELOG.md"
           tag: v${{ steps.publish.outputs.version }}
-          commit: main
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "carbon-web-components",
-  "version": "1.20.0",
+  "version": "1.21.0",
   "license": "Apache-2.0",
   "repository": "https://github.com/carbon-design-system/carbon-web-components",
   "bugs": "https://github.com/carbon-design-system/carbon-web-components/issues",


### PR DESCRIPTION
### Related Ticket(s)

No related issue

### Description

This releases v1.21.0 of Carbon Web Components.

I have also snuck in a new workflow for updating the yarn offline mirror from dependabot, as well as a slight adjustment to the publish workflow to set the token on the checkout level.

### Changelog

**New**

- `dependabot-yarn-mirror.yml` for updating the offline mirror from dependabot PRs

**Changed**

- Bumped version to `v1.21.0` in `package.json`
- Set the github token in the `action/checkout` step in `publish.yml`
