### PR TITLE
chore(ci): add git clean to remove angular artifacts

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -2,6 +2,7 @@
 /docs/js
 /tests/coverage
 /tests/snapshots
+storybook-static*
 .github
 .yarn
 es

--- a/tools/deploy.sh
+++ b/tools/deploy.sh
@@ -2,6 +2,7 @@
 
 set -e
 
+git clean -f
 mv storybook-static ../storybook-static
 cd ../storybook-static
 echo "web-components.carbondesignsystem.com" > CNAME


### PR DESCRIPTION
### Description

The `build-storybook:angular` script introduces a large amount of auto-generated DTS files. This removes them prior to running the `gh-pages` deploy script, which may be failing due to the inclusion of these files.

![image](https://user-images.githubusercontent.com/909118/154128693-352e1162-9afc-4f9e-a6df-1ee026e829cf.png)


### Changelog

**New**

- remove untracked files added by `build-storybook:angular` script
- add `storybook-static*` directories to `prettierignore`