### PR TITLE
chore: remove deprecation warnings and add snapshot update script

### DIFF
--- a/gulp-tasks/build/modules/css.js
+++ b/gulp-tasks/build/modules/css.js
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2021
+ * Copyright IBM Corp. 2020, 2022
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -57,7 +57,7 @@ const buildModulesCSS = ({ banner, dir }) =>
         fixHostPseudo(),
         autoprefixer({
           // TODO: Optimize for modern browsers here
-          browsers: ['last 1 version', 'Firefox ESR', 'ie >= 11'],
+          overrideBrowserslist: ['last 1 version', 'Firefox ESR', 'ie >= 11'],
         }),
         ...(dir === 'rtl' ? [rtlcss] : []),
       ])

--- a/gulp-tasks/test.js
+++ b/gulp-tasks/test.js
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019, 2021
+ * Copyright IBM Corp. 2019, 2022
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -9,18 +9,24 @@
 
 const gulp = require('gulp');
 const path = require('path');
-const { Server } = require('karma');
-
+const karma = require('karma');
 const config = require('./config');
 
+const { Server } = karma;
+const { parseConfig } = karma.config;
 const { cloptions, testsDir } = config;
 const { browsers, debug, specs, keepalive, noPruneSnapshot, random, updateSnapshot, useExperimentalFeatures, verbose } =
   cloptions;
 
+/**
+ * Runs the unit tests
+ *
+ * @param {Function} done done callback
+ */
 function unit(done) {
-  new Server(
+  parseConfig(
+    path.resolve(__dirname, '..', testsDir, 'karma.conf.js'),
     {
-      configFile: path.resolve(__dirname, '..', testsDir, 'karma.conf.js'),
       singleRun: !keepalive,
       customConfig: {
         browsers, // We'll massage browser list in `karma.config.js`
@@ -33,8 +39,13 @@ function unit(done) {
         verbose,
       },
     },
-    done
-  ).start();
+    { promiseConfig: true, throwErrors: true }
+  ).then(karmaConfig => {
+    const server = new Server(karmaConfig, () => {
+      done();
+    });
+    server.start();
+  });
 }
 
 gulp.task('test:unit', unit);

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "test:integration:build": "jest -c tests/integration/build/jest.config.js --runInBand",
     "test:integration:ui": "jest -c tests/integration/ui/jest.config.js --runInBand",
     "test:unit": "gulp test:unit",
+    "test:unit:updateSnapshot": "gulp test:unit --update-snapshot",
     "typecheck": "tsc --noEmit -p tsconfig.json",
     "wca": "web-component-analyzer analyze src --outFile custom-elements.json"
   },

--- a/tests/karma.conf.js
+++ b/tests/karma.conf.js
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019, 2021
+ * Copyright IBM Corp. 2019, 2022
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -30,7 +30,7 @@ module.exports = function setupKarma(config) {
   config.set({
     basePath: '..',
 
-    browsers: (browsers.length > 0 ? browsers : ['ChromeHeadless']).map(normalizeBrowser),
+    overrideBrowserslist: (browsers.length > 0 ? browsers : ['ChromeHeadless']).map(normalizeBrowser),
 
     frameworks: ['jasmine', 'snapshot'],
 

--- a/tests/karma.conf.js
+++ b/tests/karma.conf.js
@@ -30,7 +30,7 @@ module.exports = function setupKarma(config) {
   config.set({
     basePath: '..',
 
-    overrideBrowserslist: (browsers.length > 0 ? browsers : ['ChromeHeadless']).map(normalizeBrowser),
+    browsers: (browsers.length > 0 ? browsers : ['ChromeHeadless']).map(normalizeBrowser),
 
     frameworks: ['jasmine', 'snapshot'],
 

--- a/tests/karma.conf.js
+++ b/tests/karma.conf.js
@@ -48,7 +48,7 @@ module.exports = function setupKarma(config) {
     ].concat(specs.length > 0 ? specs : ['tests/karma-test-shim.js']),
 
     preprocessors: {
-      'src/**/*.[jt]s': ['webpack', 'sourcemap'], // For generatoring coverage report for untested files
+      'src/**/*.[jt]s': ['webpack', 'sourcemap'], // For generating coverage report for untested files
       'tests/karma-test-shim.js': ['webpack', 'sourcemap'],
       'tests/spec/**/*.ts': ['webpack', 'sourcemap'],
       'tests/utils/**/*.js': ['webpack', 'sourcemap'],
@@ -61,7 +61,7 @@ module.exports = function setupKarma(config) {
       resolve: {
         alias: {
           // In our development environment (where `carbon-web-components/es/icons` may not have been built yet),
-          // we load icons from `@carbon/icons` and use a WebPack loader to convert the icons to `lit-html` version
+          // we load icons from `@carbon/icons` and use a Webpack loader to convert the icons to `lit-html` version
           'carbon-web-components/es/icons': '@carbon/icons/lib',
         },
         extensions: ['.js', '.ts'],
@@ -146,7 +146,7 @@ module.exports = function setupKarma(config) {
                 options: {
                   plugins: () => [
                     require('autoprefixer')({
-                      browsers: ['last 1 version', 'ie >= 11'],
+                      overrideBrowserslist: ['last 1 version', 'ie >= 11'],
                     }),
                   ],
                 },

--- a/tests/utils/snapshot.js
+++ b/tests/utils/snapshot.js
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2022
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -38,7 +38,7 @@ beforeEach(function () {
          * @param {HTMLElement} actualElem The DOM element to match the snapshot with.
          * @param {Object} [options={}] The options.
          * @param {string} [options.mode]
-         *   `shadow` to use the `actualaElem.shadowRoot.innerHTML`. Otherwise `actualElem.outerHTML` is used.
+         *   `shadow` to use the `actualElem.shadowRoot.innerHTML`. Otherwise `actualElem.outerHTML` is used.
          * @returns {boolean}
          *   `true` if the given DOM element's content matches the snapshot or the snapshot does not exist. Otherwise throws.
          */


### PR DESCRIPTION
### Related Ticket(s)

#814 

### Description

This PR updates the karma config and gulp tasks to remove karma and autoprefixer warnings when running the test suite. It also adds an npm script for updating unit test snapshots to match our other repos

