### PR TITLE
feat(overflow-menu): add custom focus management

### DIFF
--- a/src/globals/mixins/focus.ts
+++ b/src/globals/mixins/focus.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2022
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -21,7 +21,14 @@ const FocusMixin = <T extends Constructor<HTMLElement>>(Base: T) =>
     focus() {
       // @ts-ignore: Until `delegatesFocus` is added to `ShadowRoot` definition
       if (this.shadowRoot!.delegatesFocus) {
-        super.focus();
+        const primaryFocusNode =
+          this.shadowRoot!.querySelector('[data-primary-focus]') || this.querySelector('[data-primary-focus]');
+
+        if (primaryFocusNode) {
+          (primaryFocusNode as HTMLElement).focus();
+        } else {
+          super.focus();
+        }
       } else {
         const delegateTarget = this.shadowRoot!.querySelector(selectorTabbable) || this.querySelector(selectorTabbable);
         if (delegateTarget) {


### PR DESCRIPTION
### Related Ticket(s)

#103

### Description

This PR addresses the focus management portion of the overflow menu enhancements epic. By adding `[data-primary-focus]` to an overflow menu item, the menu will focus on that item rather than the first valid item when the menu is opened

### Changelog

**Changed**

- FocusMixin now accounts for primary focus selector