### PR TITLE
fix(tabs): basic keyboard navigation

### DIFF
--- a/src/components/content-switcher/content-switcher-item.ts
+++ b/src/components/content-switcher/content-switcher-item.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019, 2021
+ * Copyright IBM Corp. 2019, 2022
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -88,7 +88,6 @@ class BXContentSwitcherItem extends FocusMixin(LitElement) {
         role="tab"
         class="${className}"
         ?disabled="${disabled}"
-        tabindex="${selected ? '0' : '-1'}"
         aria-controls="${ifNonNull(target)}"
         aria-selected="${Boolean(selected)}">
         <span class="${prefix}--content-switcher__label"><slot></slot></span>

--- a/src/components/tabs/defs.ts
+++ b/src/components/tabs/defs.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020, 2021
+ * Copyright IBM Corp. 2020, 2022
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -42,6 +42,11 @@ export enum TABS_KEYBOARD_ACTION {
    * Keyboard action to open/close menu on the trigger button or select/deselect a menu item.
    */
   TRIGGERING = 'triggering',
+
+  /**
+   * Keyboard action to trigger tab selection using enter key
+   */
+  SELECTING = 'selecting',
 }
 
 /**

--- a/src/components/tabs/tab.ts
+++ b/src/components/tabs/tab.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019, 2020
+ * Copyright IBM Corp. 2019, 2022
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -30,13 +30,6 @@ class BXTab extends BXContentSwitcherItem {
   highlighted = false;
 
   /**
-   * `true` if this tab is in a focused `<bx-tabs>`.
-   * @private
-   */
-  @property({ type: Boolean, reflect: true, attribute: 'in-focus' })
-  inFocus = false;
-
-  /**
    * Tab type.
    */
   @property({ reflect: true })
@@ -53,7 +46,12 @@ class BXTab extends BXContentSwitcherItem {
     const { disabled, selected } = this;
     // No `href`/`tabindex` to not to make this `<a>` click-focusable
     return html`
-      <a class="${prefix}--tabs__nav-link" role="tab" ?disabled="${disabled}" aria-selected="${Boolean(selected)}">
+      <a
+        class="${prefix}--tabs__nav-link"
+        role="tab"
+        tabindex="${disabled ? -1 : 0}"
+        ?disabled="${disabled}"
+        aria-selected="${Boolean(selected)}">
         <slot></slot>
       </a>
     `;

--- a/src/components/tabs/tabs.scss
+++ b/src/components/tabs/tabs.scss
@@ -1,5 +1,5 @@
 //
-// Copyright IBM Corp. 2019, 2021
+// Copyright IBM Corp. 2019, 2022
 //
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
@@ -203,20 +203,6 @@
   @include carbon--breakpoint(md) {
     background-color: transparent;
     box-shadow: none;
-  }
-}
-
-:host(#{$prefix}-tab[in-focus][selected]),
-:host(#{$prefix}-tab[in-focus][selected]:hover) {
-  @include carbon--breakpoint(md) {
-    @include focus-outline('outline');
-
-    // `[role]` is only for specificity.
-    // We have `:not()` usage in the corresponding Carbon core style
-    // which puts specificity of "specific" scenario though the style is for "regular" scenario
-    a.#{$prefix}--tabs__nav-link[role] {
-      border-bottom-width: 2px;
-    }
   }
 }
 


### PR DESCRIPTION
### Related Ticket(s)
#970

### Description
This PR ensures that the Tabs and Content Switcher components are able to be work with tab navigation.

### Changelog

**New**

- added `tab-index` in the `tab` shadow dom

**Changed**

- triggering the content switching upon pressing the enter key

**Removed**

- remove unneeded `inFocus` property in the tab item component
