### PR TITLE
fix: replace `list` with `link`

### DIFF
--- a/src/components/link/link-story.mdx
+++ b/src/components/link/link-story.mdx
@@ -18,10 +18,10 @@ Here's a quick example to get you started.
 ### JS (via import)
 
 ```javascript
-import 'carbon-web-components/es/components/list/index.js';
+import 'carbon-web-components/es/components/link/index.js';
 ```
 
-<Description markdown={`${cdnJs({ components: ['list'] })}`} />
+<Description markdown={`${cdnJs({ components: ['link'] })}`} />
 
 <Description markdown={`${cdnCss()}`} />
 


### PR DESCRIPTION
### Description

The documentation of the `link` component referenced the `list` component.

### Changelog

**Changed**

- Replaced `list` with `link`.
