### PR TITLE
docs(input): show password visibility knob only for password input

### DIFF
--- a/src/components/input/stories/helpers.ts
+++ b/src/components/input/stories/helpers.ts
@@ -39,9 +39,7 @@ const createProps = ({ boolean, textNonEmpty, select }) => {
     invalid: boolean('Invalid (invalid)', false),
     onInput: action('input'),
     showPasswordVisibilityToggle:
-      type === INPUT_TYPE.TEXT || type === INPUT_TYPE.PASSWORD
-        ? boolean('Show password visibility toggle (show-password-visibility-toggle)', false)
-        : null,
+      type === INPUT_TYPE.PASSWORD ? boolean('Show password visibility toggle (show-password-visibility-toggle)', false) : null,
     size: select('Input size (size)', sizes, INPUT_SIZE.REGULAR),
     type,
   };


### PR DESCRIPTION
### Description

This PR updates the Input story so that the `showPasswordVisibilityToggle` knob is only visible when the input knob is set to "password"

### Changelog

**Changed**

- Input story knob helpers