### PR TITLE
fix(file-uploader): added missing docs for drop-container

### DIFF
--- a/src/components/file-uploader/file-uploader-story.mdx
+++ b/src/components/file-uploader/file-uploader-story.mdx
@@ -39,6 +39,10 @@ import 'carbon-web-components/es/components/file-uploader/index.js';
 
 <Props of="bx-file-uploader" />
 
+## `<bx-file-drop-container>` attributes, properties and events
+
+<Props of="bx-file-drop-container" />
+
 ## `<bx-file-uploader-item>` attributes, properties and events
 
 Note: For `boolean` attributes, `true` means simply setting the attribute (e.g. `<bx-file-uploader-item invalid>`) and `false` means not setting the attribute (e.g. `<bx-file-uploader-item>` without `invalid` attribute).


### PR DESCRIPTION
### Related Ticket(s)

No ticket

### Description

Fixing the file-drop-container documentation that is missing in vanilla web-components story for file-uploader.

### Changelog

**Changed**

- Documentation for file-uploader - in the file-drop-container section
